### PR TITLE
Enable Inter-procedural Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.9)
 project(BSFS C)
 
 add_compile_options(-Wall -Wextra -Wpedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.9)
 project(BSFS C)
 
+include(CheckIPOSupported)
+
+check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
+if (ipo_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+    message(WARNING "IPO is not supported: ${ipo_output}")
+endif()
+
 add_compile_options(-Wall -Wextra -Wpedantic)
 
 add_subdirectory(src)


### PR DESCRIPTION
This defers optimization and codegen to link-time, allowing the compiler to see all of the code and potentially perform cross-module optimizations.