### PR TITLE
Add Bit Utilities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR} ${FUSE3_INCLUDE_DIR})
 
 set(SOURCE_FILES
   bft.c
+  bit_util.c
   enc.c
   fuse_ops.c
   keytab.c

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -1,0 +1,1 @@
+#include "bit_util.h"

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -13,3 +13,13 @@ void write_big_endian(void* buf, uint32_t host_endian) {
   uint32_t big_endian = htonl(host_endian);
   memcpy(buf, &big_endian, sizeof(uint32_t));
 }
+
+bool get_bit(const void* buf, size_t bit) {
+  const uint8_t* buf_bytes = (const uint8_t*) buf;
+  return (buf_bytes[bit / 8] >> (7 - bit % 8)) & 1;
+}
+
+void set_bit(void* buf, size_t bit, bool val) {
+  uint8_t* buf_bytes = (uint8_t*) buf;
+  buf_bytes[bit / 8] |= (uint8_t) val << (7 - bit % 8);
+}

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -20,6 +20,10 @@ bool get_bit(const void* buf, size_t bit) {
 }
 
 void set_bit(void* buf, size_t bit, bool val) {
-  uint8_t* buf_bytes = (uint8_t*) buf;
-  buf_bytes[bit / 8] |= (uint8_t) val << (7 - bit % 8);
+  uint8_t* byte = (uint8_t*) buf + bit / 8;
+  if (val) {
+    *byte |= (uint8_t) 1 << (7 - bit % 8);
+  } else {
+    *byte &= ~((uint8_t) 1 << (7 - bit % 8));
+  }
 }

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -1,1 +1,15 @@
 #include "bit_util.h"
+
+#include <arpa/inet.h>
+#include <string.h>
+
+uint32_t read_big_endian(const void* buf) {
+  uint32_t big_endian;
+  memcpy(&big_endian, buf, sizeof(uint32_t));
+  return ntohl(big_endian);
+}
+
+void write_big_endian(void* buf, uint32_t host_endian) {
+  uint32_t big_endian = htonl(host_endian);
+  memcpy(buf, &big_endian, sizeof(uint32_t));
+}

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -14,16 +14,24 @@ void write_big_endian(void* buf, uint32_t host_endian) {
   memcpy(buf, &big_endian, sizeof(uint32_t));
 }
 
+static size_t byte_from_bit(size_t bit) {
+  return bit / 8;
+}
+
+static size_t bit_rem_from_bit(size_t bit) {
+  return 7 - bit % 8;
+}
+
 bool get_bit(const void* buf, size_t bit) {
-  const uint8_t* buf_bytes = (const uint8_t*) buf;
-  return (buf_bytes[bit / 8] >> (7 - bit % 8)) & 1;
+  const uint8_t* byte = (const uint8_t*) buf + byte_from_bit(bit);
+  return (*byte >> bit_rem_from_bit(bit)) & 1;
 }
 
 void set_bit(void* buf, size_t bit, bool val) {
-  uint8_t* byte = (uint8_t*) buf + bit / 8;
+  uint8_t* byte = (uint8_t*) buf + byte_from_bit(bit);
   if (val) {
-    *byte |= (uint8_t) 1 << (7 - bit % 8);
+    *byte |= (uint8_t) 1 << bit_rem_from_bit(bit);
   } else {
-    *byte &= ~((uint8_t) 1 << (7 - bit % 8));
+    *byte &= ~((uint8_t) 1 << bit_rem_from_bit(bit));
   }
 }

--- a/src/bit_util.h
+++ b/src/bit_util.h
@@ -1,0 +1,4 @@
+#ifndef BS_BIT_UTIL_H
+#define BS_BIT_UTIL_H
+
+#endif // BS_BIT_UTIL_H

--- a/src/bit_util.h
+++ b/src/bit_util.h
@@ -1,4 +1,14 @@
 #ifndef BS_BIT_UTIL_H
 #define BS_BIT_UTIL_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+uint32_t read_big_endian(const void* buf);
+void write_big_endian(void* buf, uint32_t host_endian);
+
+bool get_bit(const void* buf, size_t bit);
+void set_bit(void* buf, size_t bit, bool val);
+
 #endif // BS_BIT_UTIL_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ pkg_check_modules(CHECK REQUIRED check)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/ ${CHECK_INCLUDE_DIR})
 
 set(TEST_SOURCES
+  test_bit_util.c
   test_bft.c
   test_enc.c
   test_fuse_ops.c

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,4 +1,5 @@
 #include "test_bft.h"
+#include "test_bit_util.h"
 #include "test_disk.h"
 #include "test_enc.h"
 #include "test_fuse_ops.h"
@@ -9,6 +10,7 @@
 
 int main() {
   SRunner* runner = srunner_create(bft_suite());
+  srunner_add_suite(runner, bit_util_suite());
   srunner_add_suite(runner, enc_suite());
   srunner_add_suite(runner, fuse_ops_suite());
   srunner_add_suite(runner, keytab_suite());

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -28,6 +28,14 @@ START_TEST(test_set_bit) {
 }
 END_TEST
 
+START_TEST(test_get_bit) {
+  uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef };
+  ck_assert(!get_bit(buf, 7));
+  ck_assert(get_bit(buf, 16));
+  ck_assert(get_bit(buf, 31));
+}
+END_TEST
+
 Suite* bit_util_suite(void) {
   Suite* suite = suite_create("bit_util");
 
@@ -38,6 +46,7 @@ Suite* bit_util_suite(void) {
 
   TCase* bit_tcase = tcase_create("bits");
   tcase_add_test(bit_tcase, test_set_bit);
+  tcase_add_test(bit_tcase, test_get_bit);
   suite_add_tcase(suite, bit_tcase);
 
   return suite;

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -19,6 +19,15 @@ START_TEST(test_read_big_endian) {
 }
 END_TEST
 
+START_TEST(test_set_bit) {
+  uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef };
+  set_bit(buf, 7, 1);
+  ck_assert_int_eq(memcmp(buf, "\xdf\xad\xbe\xef", sizeof(buf)), 0);
+  set_bit(buf, 27, 0);
+  ck_assert_int_eq(memcmp(buf, "\xdf\xad\xbe\xbf", sizeof(buf)), 0);
+}
+END_TEST
+
 Suite* bit_util_suite(void) {
   Suite* suite = suite_create("bit_util");
 
@@ -26,6 +35,10 @@ Suite* bit_util_suite(void) {
   tcase_add_test(endian_tcase, test_write_big_endian);
   tcase_add_test(endian_tcase, test_read_big_endian);
   suite_add_tcase(suite, endian_tcase);
+
+  TCase* bit_tcase = tcase_create("bits");
+  tcase_add_test(bit_tcase, test_set_bit);
+  suite_add_tcase(suite, bit_tcase);
 
   return suite;
 }

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -13,11 +13,18 @@ START_TEST(test_write_big_endian) {
 }
 END_TEST
 
+START_TEST(test_read_big_endian) {
+  uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef };
+  ck_assert_uint_eq(read_big_endian(buf), 0xdeadbeef);
+}
+END_TEST
+
 Suite* bit_util_suite(void) {
   Suite* suite = suite_create("bit_util");
 
   TCase* endian_tcase = tcase_create("endian");
   tcase_add_test(endian_tcase, test_write_big_endian);
+  tcase_add_test(endian_tcase, test_read_big_endian);
   suite_add_tcase(suite, endian_tcase);
 
   return suite;

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -1,7 +1,24 @@
 #include "test_bit_util.h"
 
+#include "bit_util.h"
+#include <string.h>
+
+START_TEST(test_write_big_endian) {
+  uint32_t val = 0xdeadbeef;
+  uint8_t expected[] = { 0xde, 0xad, 0xbe, 0xef };
+
+  uint8_t buf[sizeof(uint32_t)];
+  write_big_endian(buf, val);
+  ck_assert_int_eq(memcmp(buf, expected, sizeof(uint32_t)), 0);
+}
+END_TEST
+
 Suite* bit_util_suite(void) {
   Suite* suite = suite_create("bit_util");
+
+  TCase* endian_tcase = tcase_create("endian");
+  tcase_add_test(endian_tcase, test_write_big_endian);
+  suite_add_tcase(suite, endian_tcase);
 
   return suite;
 }

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -1,0 +1,7 @@
+#include "test_bit_util.h"
+
+Suite* bit_util_suite(void) {
+  Suite* suite = suite_create("bit_util");
+
+  return suite;
+}

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -36,6 +36,16 @@ START_TEST(test_get_bit) {
 }
 END_TEST
 
+START_TEST(test_get_set_bit_roundtrip) {
+  uint8_t buf[16] = { 0 };
+  ck_assert(!get_bit(buf, 123));
+  set_bit(buf, 123, 1);
+  ck_assert(get_bit(buf, 123));
+  set_bit(buf, 123, 0);
+  ck_assert(!get_bit(buf, 123));
+}
+END_TEST
+
 Suite* bit_util_suite(void) {
   Suite* suite = suite_create("bit_util");
 
@@ -47,6 +57,7 @@ Suite* bit_util_suite(void) {
   TCase* bit_tcase = tcase_create("bits");
   tcase_add_test(bit_tcase, test_set_bit);
   tcase_add_test(bit_tcase, test_get_bit);
+  tcase_add_test(bit_tcase, test_get_set_bit_roundtrip);
   suite_add_tcase(suite, bit_tcase);
 
   return suite;

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -23,8 +23,8 @@ START_TEST(test_set_bit) {
   uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef };
   set_bit(buf, 7, 1);
   ck_assert_int_eq(memcmp(buf, "\xdf\xad\xbe\xef", sizeof(buf)), 0);
-  set_bit(buf, 27, 0);
-  ck_assert_int_eq(memcmp(buf, "\xdf\xad\xbe\xbf", sizeof(buf)), 0);
+  set_bit(buf, 8, 0);
+  ck_assert_int_eq(memcmp(buf, "\xdf\x2d\xbe\xef", sizeof(buf)), 0);
 }
 END_TEST
 

--- a/tests/test_bit_util.h
+++ b/tests/test_bit_util.h
@@ -1,0 +1,8 @@
+#ifndef TEST_BIT_UTIL_H
+#define TEST_BIT_UTIL_H
+
+#include <check.h>
+
+Suite* bit_util_suite(void);
+
+#endif // TEST_BIT_UTIL_H


### PR DESCRIPTION
This module was motivated by the fact that many other areas of the code require the ability to manipulate individual bits and bytes in memory, and these operations are currently implemented as (duplicated) static functions in various source files.

In particular, the following components require big-endian reads/writes:
* BFT
* cluster
* keytable

The following components require individual bit manipulation:
* stego
* cluster