### PR TITLE
Implement open file table (OFT)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,27 +7,15 @@ include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR} ${FUSE3_INCLUDE_DIR})
 
 set(SOURCE_FILES
   bft.c
-  bft.h
   bit_util.c
-  bit_util.h
-  bsfs_priv.h
   bsfs.c
-  bsfs.h
   cluster.c
-  cluster.h
   disk.c
-  disk.h
   enc.c
-  enc.h
   fuse_ops.c
-  fuse_ops.h
-  fuse_wrap.h
   keytab.c
-  keytab.h
   stego.c
-  stego.h
   vector.c
-  vector.h
 )
 
 add_library(bsfs-core ${SOURCE_FILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,15 +7,27 @@ include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR} ${FUSE3_INCLUDE_DIR})
 
 set(SOURCE_FILES
   bft.c
+  bft.h
   bit_util.c
+  bit_util.h
+  bsfs_priv.h
   bsfs.c
+  bsfs.h
   cluster.c
-  enc.c
-  fuse_ops.c
-  keytab.c
-  stego.c
+  cluster.h
   disk.c
+  disk.h
+  enc.c
+  enc.h
+  fuse_ops.c
+  fuse_ops.h
+  fuse_wrap.h
+  keytab.c
+  keytab.h
+  stego.c
+  stego.h
   vector.c
+  vector.h
 )
 
 add_library(bsfs-core ${SOURCE_FILES})

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -119,6 +119,11 @@ static int remove_open_file(bs_file_table_t* table, bs_file_t file) {
 }
 
 static int rehash_open_files(bs_file_table_t* table, size_t bucket_count) {
+  if (!bucket_count || bucket_count & (bucket_count - 1)) {
+    // not a power of 2
+    return -EINVAL;
+  }
+
   int ret = realloc_buckets(table, bucket_count);
   if (ret < 0) {
     return ret;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -175,7 +175,13 @@ int bs_oft_init(bs_oft_t* table) {
   if (ret < 0) {
     return ret;
   }
-  return -pthread_mutex_init(&table->lock, NULL);
+
+  ret = -pthread_mutex_init(&table->lock, NULL);
+  if (ret < 0) {
+    free(table->buckets);
+  }
+
+  return ret;
 }
 
 void bs_oft_destroy(bs_oft_t* table) {

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -114,13 +114,13 @@ static int remove_open_file(bs_file_table_t* table, bs_file_t file) {
     return -EINVAL;
   }
 
-  *prev_link = file->next;
-
   if (*table->buckets[bucket] == file &&
       !matches_bucket(file->next, bucket, table->bucket_count)) {
     // `file` was the only entry in the bucket - empty it
     table->buckets[bucket] = NULL;
   }
+
+  *prev_link = file->next;
 
   if (*prev_link) {
     // patch other bucket with new next pointer

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -123,10 +123,14 @@ static int oft_remove(bs_oft_t* table, bs_file_t file) {
   *prev_link = file->next;
 
   if (*prev_link) {
-    // patch other bucket with new next pointer
     size_t next_bucket =
         oft_bucket_of((*prev_link)->index, table->bucket_count);
-    table->buckets[next_bucket] = prev_link;
+
+    if (next_bucket != bucket) {
+      // the next item is in a different bucket - patch it with new next
+      // pointer
+      table->buckets[next_bucket] = prev_link;
+    }
   }
 
   table->size--;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -113,6 +113,7 @@ static int remove_open_file(bs_file_table_t* table, bs_file_t file) {
     size_t next_bucket = bucket_of((*prev_link)->index, table->bucket_count);
     table->buckets[next_bucket] = prev_link;
   }
+  table->size--;
 
   return 0;
 }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -136,6 +136,21 @@ static int rehash_open_files(bs_file_table_t* table, size_t bucket_count) {
   return 0;
 }
 
+static int add_open_file(bs_file_table_t* table, bs_file_t file) {
+  if (table->size + 1 > table->bucket_count * FTAB_MAX_LOAD_FACTOR) {
+    // note: still power-of-2
+    int rehash_status = rehash_open_files(table, 2 * table->bucket_count);
+    if (rehash_status < 0) {
+      return rehash_status;
+    }
+  }
+
+  insert_open_file(table, file);
+  table->size++;
+
+  return 0;
+}
+
 int bs_file_table_init(bs_file_table_t* table) {
   memset(table, 0, sizeof(bs_file_table_t));
   int ret = realloc_buckets(table, FTAB_INITIAL_BUCKET_COUNT);

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -11,11 +11,10 @@
 
 static int create_open_file(struct bs_open_level_impl* level,
                             bft_offset_t index, bs_file_t* out) {
-  bs_file_t file = (bs_file_t) malloc(sizeof(struct bs_file_impl));
+  bs_file_t file = (bs_file_t) calloc(1, sizeof(struct bs_file_impl));
   if (!file) {
     return -ENOMEM;
   }
-  memset(file, 0, sizeof(struct bs_file_impl));
 
   int ret = -pthread_rwlock_init(&file->lock, NULL);
   if (ret < 0) {

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -81,12 +81,12 @@ static bs_file_t oft_find(bs_oft_t* table, bft_offset_t index) {
 static void oft_do_insert(bs_oft_t* table, bs_file_t file) {
   size_t bucket = oft_bucket_of(file->index, table->bucket_count);
   if (table->buckets[bucket]) {
-    // insert after existing node
+    // insert at head of existing bucket
     bs_file_t* prev_link = table->buckets[bucket];
     file->next = *prev_link;
     *prev_link = file;
   } else {
-    // insert at head
+    // insert at head of table
     file->next = table->head;
     table->head = file;
     table->buckets[bucket] = &table->head;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -110,11 +110,19 @@ static int remove_open_file(bs_file_table_t* table, bs_file_t file) {
   }
 
   *prev_link = file->next;
+
+  if (*table->buckets[bucket] == file &&
+      !matches_bucket(file->next, bucket, table->bucket_count)) {
+    // `file` was the only entry in the bucket - empty it
+    table->buckets[bucket] = NULL;
+  }
+
   if (*prev_link) {
     // patch other bucket with new next pointer
     size_t next_bucket = bucket_of((*prev_link)->index, table->bucket_count);
     table->buckets[next_bucket] = prev_link;
   }
+
   table->size--;
 
   return 0;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -15,6 +15,7 @@ static int create_open_file(struct bs_open_level_impl* level,
   if (!file) {
     return -ENOMEM;
   }
+  memset(file, 0, sizeof(struct bs_file_impl));
 
   int ret = -pthread_rwlock_init(&file->lock, NULL);
   if (ret < 0) {
@@ -22,6 +23,7 @@ static int create_open_file(struct bs_open_level_impl* level,
     return ret;
   }
 
+  // note: initial refcount is 0 (not 1)
   file->index = index;
   file->level = level;
   *out = file;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -2,7 +2,31 @@
 
 #include "stego.h"
 #include <errno.h>
-#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FTAB_INITIAL_BUCKET_COUNT 8
+#define FTAB_MAX_LOAD_FACTOR 1.f
+
+static int realloc_buckets(bs_file_table_t* table, size_t bucket_count) {
+  bs_file_t* new_buckets = (bs_file_t*) calloc(bucket_count, sizeof(bs_file_t));
+  if (!new_buckets) {
+    return -ENOMEM;
+  }
+  free(table->buckets);
+  table->buckets = new_buckets;
+  table->bucket_count = bucket_count;
+  return 0;
+}
+
+int bs_file_table_init(bs_file_table_t* table) {
+  memset(table, 0, sizeof(bs_file_table_t));
+  int ret = realloc_buckets(table, FTAB_INITIAL_BUCKET_COUNT);
+  if (ret < 0) {
+    return ret;
+  }
+  return -pthread_mutex_init(&table->lock, NULL);
+}
 
 int bsfs_init(int fd, bs_bsfs_t* fs) {
   return -ENOSYS;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -61,6 +61,21 @@ static bs_file_t find_open_file(bs_file_table_t* table, bft_offset_t index) {
   return NULL;
 }
 
+static void insert_open_file(bs_file_table_t* table, bs_file_t file) {
+  size_t bucket = bucket_of(file->index, table->bucket_count);
+  if (table->buckets[bucket]) {
+    // insert after existing node
+    bs_file_t prev = table->buckets[bucket];
+    file->next = prev->next;
+    prev->next = file;
+  } else {
+    // insert at head
+    file->next = table->head;
+    table->head = file;
+    table->buckets[bucket] = file;
+  }
+}
+
 int bs_file_table_init(bs_file_table_t* table) {
   memset(table, 0, sizeof(bs_file_table_t));
   int ret = realloc_buckets(table, FTAB_INITIAL_BUCKET_COUNT);

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -1,34 +1,8 @@
-#include "bsfs.h"
+#include "bsfs_priv.h"
 
-#include "bft.h"
-#include "disk.h"
 #include "stego.h"
 #include <errno.h>
 #include <pthread.h>
-
-struct bs_file_impl {
-  struct bs_open_level_impl* level;
-  bft_offset_t index;
-  _Atomic int refcount; // Atomically counts the amount of references to file.
-  pthread_rwlock_t file_lock;
-};
-
-struct bs_open_level_impl {
-  struct bs_bsfs_impl* bsfs;
-  stego_key_t key;
-  char* pass;
-  void* bft;
-  void* bitmap;
-  // TODO: open_files
-  pthread_mutex_t ftab_lock;      // Locks the Open File Table.
-  pthread_rwlock_t metadata_lock; // Used for locking BFT and Bitmap.
-};
-
-struct bs_bsfs_impl {
-  struct bs_open_level_impl levels[STEGO_USER_LEVEL_COUNT];
-  bs_disk_t disk;
-  pthread_mutex_t level_lock;
-};
 
 int bsfs_init(int fd, bs_bsfs_t* fs) {
   return -ENOSYS;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -50,9 +50,10 @@ static size_t bucket_of(bft_offset_t index, size_t bucket_count) {
 
 static bs_file_t find_open_file(bs_file_table_t* table, bft_offset_t index) {
   size_t bucket = bucket_of(index, table->bucket_count);
-  bs_file_t iter = table->buckets[bucket];
 
-  while (iter && bucket_of(iter->index, table->bucket_count) == bucket) {
+  for (bs_file_t iter = table->buckets[bucket];
+       iter && bucket_of(iter->index, table->bucket_count) == bucket;
+       iter = iter->next) {
     if (iter->index == index) {
       return iter;
     }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define FTAB_INITIAL_BUCKET_COUNT (1 << 3) // must be power of 2
-#define FTAB_MAX_LOAD_FACTOR 1.f
+#define OFT_INITIAL_BUCKET_COUNT (1 << 3) // must be power of 2
+#define OFT_MAX_LOAD_FACTOR 1.f
 
 static int create_open_file(struct bs_open_level_impl* level,
                             bft_offset_t index, bs_file_t* out) {
@@ -156,7 +156,7 @@ static int oft_rehash(bs_oft_t* table, size_t bucket_count) {
 }
 
 static int oft_insert(bs_oft_t* table, bs_file_t file) {
-  if (table->size + 1 > table->bucket_count * FTAB_MAX_LOAD_FACTOR) {
+  if (table->size + 1 > table->bucket_count * OFT_MAX_LOAD_FACTOR) {
     // note: still power-of-2
     int rehash_status = oft_rehash(table, 2 * table->bucket_count);
     if (rehash_status < 0) {
@@ -172,7 +172,7 @@ static int oft_insert(bs_oft_t* table, bs_file_t file) {
 
 int bs_oft_init(bs_oft_t* table) {
   memset(table, 0, sizeof(bs_oft_t));
-  int ret = oft_realloc_buckets(table, FTAB_INITIAL_BUCKET_COUNT);
+  int ret = oft_realloc_buckets(table, OFT_INITIAL_BUCKET_COUNT);
   if (ret < 0) {
     return ret;
   }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -8,6 +8,31 @@
 #define FTAB_INITIAL_BUCKET_COUNT 8
 #define FTAB_MAX_LOAD_FACTOR 1.f
 
+static int create_open_file(struct bs_open_level_impl* level,
+                            bft_offset_t index, bs_file_t* out) {
+  bs_file_t file = (bs_file_t) malloc(sizeof(struct bs_file_impl));
+  if (!file) {
+    return -ENOMEM;
+  }
+
+  int ret = -pthread_rwlock_init(&file->file_lock, NULL);
+  if (ret < 0) {
+    free(file);
+    return ret;
+  }
+
+  file->index = index;
+  file->level = level;
+  *out = file;
+
+  return 0;
+}
+
+static void destroy_open_file(bs_file_t file) {
+  pthread_rwlock_destroy(&file->file_lock);
+  free(file);
+}
+
 static int realloc_buckets(bs_file_table_t* table, size_t bucket_count) {
   bs_file_t* new_buckets = (bs_file_t*) calloc(bucket_count, sizeof(bs_file_t));
   if (!new_buckets) {
@@ -51,11 +76,11 @@ int bsfs_release(bs_file_t file) {
   return -ENOSYS;
 }
 
-ssize_t bsfs_read(bs_file_t file, void* buf, size_t size, off_t off) {
+ssize_t bsfs_read(bs_file_t file, void* buf, size_t size, off_t index) {
   return -ENOSYS;
 }
 
-ssize_t bsfs_write(bs_file_t file, const void* buf, size_t size, off_t off) {
+ssize_t bsfs_write(bs_file_t file, const void* buf, size_t size, off_t index) {
   return -ENOSYS;
 }
 

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -136,8 +136,8 @@ static int oft_remove(bs_oft_t* table, bs_file_t file) {
   return 0;
 }
 
-static int oft_rehash(bs_oft_t* table, size_t bucket_count) {
-  int ret = oft_realloc_buckets(table, bucket_count);
+static int oft_rehash(bs_oft_t* table, size_t new_bucket_count) {
+  int ret = oft_realloc_buckets(table, new_bucket_count);
   if (ret < 0) {
     return ret;
   }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -15,7 +15,7 @@ static int create_open_file(struct bs_open_level_impl* level,
     return -ENOMEM;
   }
 
-  int ret = -pthread_rwlock_init(&file->file_lock, NULL);
+  int ret = -pthread_rwlock_init(&file->lock, NULL);
   if (ret < 0) {
     free(file);
     return ret;
@@ -29,7 +29,7 @@ static int create_open_file(struct bs_open_level_impl* level,
 }
 
 static void destroy_open_file(bs_file_t file) {
-  pthread_rwlock_destroy(&file->file_lock);
+  pthread_rwlock_destroy(&file->lock);
   free(file);
 }
 

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -37,6 +37,11 @@ static void destroy_open_file(bs_file_t file) {
 }
 
 static int realloc_buckets(bs_file_table_t* table, size_t bucket_count) {
+  if (!bucket_count || bucket_count & (bucket_count - 1)) {
+    // not a power of 2
+    return -EINVAL;
+  }
+
   bs_file_t** new_buckets =
       (bs_file_t**) calloc(bucket_count, sizeof(bs_file_t*));
   if (!new_buckets) {
@@ -129,11 +134,6 @@ static int remove_open_file(bs_file_table_t* table, bs_file_t file) {
 }
 
 static int rehash_open_files(bs_file_table_t* table, size_t bucket_count) {
-  if (!bucket_count || bucket_count & (bucket_count - 1)) {
-    // not a power of 2
-    return -EINVAL;
-  }
-
   int ret = realloc_buckets(table, bucket_count);
   if (ret < 0) {
     return ret;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -53,6 +53,18 @@ int bs_file_table_init(bs_file_table_t* table) {
   return -pthread_mutex_init(&table->lock, NULL);
 }
 
+void bs_file_table_destroy(bs_file_table_t* table) {
+  pthread_mutex_destroy(&table->lock);
+  free(table->buckets);
+
+  bs_file_t iter = table->head;
+  while (iter) {
+    bs_file_t next = iter->next;
+    destroy_open_file(iter);
+    iter = next;
+  }
+}
+
 int bsfs_init(int fd, bs_bsfs_t* fs) {
   return -ENOSYS;
 }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -76,6 +76,24 @@ static void insert_open_file(bs_file_table_t* table, bs_file_t file) {
   }
 }
 
+static int rehash_open_files(bs_file_table_t* table, size_t bucket_count) {
+  int ret = realloc_buckets(table, bucket_count);
+  if (ret < 0) {
+    return ret;
+  }
+
+  bs_file_t iter = table->head;
+  table->head = NULL;
+
+  while (iter) {
+    bs_file_t next = iter->next;
+    insert_open_file(table, iter);
+    iter = next;
+  }
+
+  return 0;
+}
+
 int bs_file_table_init(bs_file_table_t* table) {
   memset(table, 0, sizeof(bs_file_table_t));
   int ret = realloc_buckets(table, FTAB_INITIAL_BUCKET_COUNT);

--- a/src/bsfs.h
+++ b/src/bsfs.h
@@ -6,7 +6,6 @@
 #include <sys/stat.h>
 
 typedef struct bs_file_impl* bs_file_t;
-typedef struct bs_open_level_impl* bs_open_level_t;
 typedef struct bs_bsfs_impl* bs_bsfs_t;
 
 int bsfs_init(int fd, bs_bsfs_t* fs);

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -40,4 +40,11 @@ struct bs_bsfs_impl {
   bs_disk_t disk;
 };
 
+int bs_file_table_init(struct bs_file_table* table);
+void bs_file_table_destroy(struct bs_file_table* table);
+
+int bs_file_table_open(struct bs_file_table* table, bft_offset_t off,
+                       bs_file_t* file);
+int bs_file_table_release(struct bs_file_table* table, bs_file_t file);
+
 #endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -11,6 +11,14 @@ struct bs_file_impl {
   bft_offset_t index;
   atomic_int refcount; // Atomically counts the amount of references to file.
   pthread_rwlock_t file_lock;
+  bs_file_t next;
+};
+
+struct bs_file_table {
+  bs_file_t head;
+  bs_file_t* buckets;
+  size_t bucket_count;
+  size_t size;
 };
 
 struct bs_open_level_impl {

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -43,8 +43,8 @@ struct bs_bsfs_impl {
 int bs_file_table_init(bs_file_table_t* table);
 void bs_file_table_destroy(struct bs_file_table* table);
 
-int bs_file_table_open(bs_file_table_t* table, bft_offset_t off,
-                       bs_file_t* file);
+int bs_file_table_open(bs_file_table_t* table, struct bs_open_level_impl* level,
+                       bft_offset_t off, bs_file_t* file);
 int bs_file_table_release(bs_file_table_t* table, bs_file_t file);
 
 #endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -8,10 +8,12 @@
 
 struct bs_file_impl {
   struct bs_open_level_impl* level;
+
   bft_offset_t index;
-  atomic_int refcount; // Atomically counts the amount of references to file.
-  pthread_rwlock_t file_lock;
-  bs_file_t next;
+  atomic_int refcount;
+  pthread_rwlock_t file_lock; // Protects reads and writes to the file
+
+  bs_file_t next; // For chaining in the table
 };
 
 struct bs_file_table {
@@ -28,14 +30,14 @@ struct bs_open_level_impl {
   void* bft;
   void* bitmap;
   // TODO: open_files
-  pthread_mutex_t ftab_lock;      // Locks the Open File Table.
-  pthread_rwlock_t metadata_lock; // Used for locking BFT and Bitmap.
+  pthread_mutex_t ftab_lock;      // Protects open file table
+  pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
 };
 
 struct bs_bsfs_impl {
   struct bs_open_level_impl levels[STEGO_USER_LEVEL_COUNT];
+  pthread_mutex_t level_lock; // Protects `levels`
   bs_disk_t disk;
-  pthread_mutex_t level_lock;
 };
 
 #endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -11,7 +11,7 @@ struct bs_file_impl {
 
   bft_offset_t index;
   atomic_int refcount;
-  pthread_rwlock_t file_lock; // Protects reads and writes to the file
+  pthread_rwlock_t lock; // Protects reads and writes to the file
 
   bs_file_t next; // For chaining in the table
 };
@@ -44,7 +44,7 @@ int bs_file_table_init(bs_file_table_t* table);
 void bs_file_table_destroy(struct bs_file_table* table);
 
 int bs_file_table_open(bs_file_table_t* table, struct bs_open_level_impl* level,
-                       bft_offset_t off, bs_file_t* file);
+                       bft_offset_t index, bs_file_t* file);
 int bs_file_table_release(bs_file_table_t* table, bs_file_t file);
 
 #endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -16,13 +16,13 @@ struct bs_file_impl {
   bs_file_t next; // For chaining in the table
 };
 
-typedef struct bs_file_table {
+typedef struct bs_oft {
   bs_file_t head;
   bs_file_t** buckets; // Array of next pointers
   size_t bucket_count;
   size_t size;
   pthread_mutex_t lock; // Protects all table operations
-} bs_file_table_t;
+} bs_oft_t;
 
 struct bs_open_level_impl {
   bs_bsfs_t fs;
@@ -30,7 +30,7 @@ struct bs_open_level_impl {
   char* pass;
   void* bft;
   void* bitmap;
-  bs_file_table_t open_files;
+  bs_oft_t open_files;
   pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
 };
 
@@ -40,11 +40,11 @@ struct bs_bsfs_impl {
   bs_disk_t disk;
 };
 
-int bs_file_table_init(bs_file_table_t* table);
-void bs_file_table_destroy(bs_file_table_t* table);
+int bs_oft_init(bs_oft_t* table);
+void bs_oft_destroy(bs_oft_t* table);
 
-int bs_file_table_open(bs_file_table_t* table, struct bs_open_level_impl* level,
-                       bft_offset_t index, bs_file_t* file);
-int bs_file_table_release(bs_file_table_t* table, bs_file_t file);
+int bs_oft_get(bs_oft_t* table, struct bs_open_level_impl* level,
+               bft_offset_t index, bs_file_t* file);
+int bs_oft_release(bs_oft_t* table, bs_file_t file);
 
 #endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -18,7 +18,7 @@ struct bs_file_impl {
 
 typedef struct bs_file_table {
   bs_file_t head;
-  bs_file_t* buckets;
+  bs_file_t** buckets; // Array of next pointers
   size_t bucket_count;
   size_t size;
   pthread_mutex_t lock; // Protects all table operations

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -30,7 +30,7 @@ struct bs_open_level_impl {
   char* pass;
   void* bft;
   void* bitmap;
-  struct bs_file_table open_files;
+  bs_file_table_t open_files;
   pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
 };
 
@@ -41,7 +41,7 @@ struct bs_bsfs_impl {
 };
 
 int bs_file_table_init(bs_file_table_t* table);
-void bs_file_table_destroy(struct bs_file_table* table);
+void bs_file_table_destroy(bs_file_table_t* table);
 
 int bs_file_table_open(bs_file_table_t* table, struct bs_open_level_impl* level,
                        bft_offset_t index, bs_file_t* file);

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -1,0 +1,33 @@
+#ifndef BS_BSFS_PRIV_H
+#define BS_BSFS_PRIV_H
+
+#include "bsfs.h"
+#include "disk.h"
+#include <pthread.h>
+#include <stdatomic.h>
+
+struct bs_file_impl {
+  struct bs_open_level_impl* level;
+  bft_offset_t index;
+  atomic_int refcount; // Atomically counts the amount of references to file.
+  pthread_rwlock_t file_lock;
+};
+
+struct bs_open_level_impl {
+  bs_bsfs_t bsfs;
+  stego_key_t key;
+  char* pass;
+  void* bft;
+  void* bitmap;
+  // TODO: open_files
+  pthread_mutex_t ftab_lock;      // Locks the Open File Table.
+  pthread_rwlock_t metadata_lock; // Used for locking BFT and Bitmap.
+};
+
+struct bs_bsfs_impl {
+  struct bs_open_level_impl levels[STEGO_USER_LEVEL_COUNT];
+  bs_disk_t disk;
+  pthread_mutex_t level_lock;
+};
+
+#endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -16,13 +16,13 @@ struct bs_file_impl {
   bs_file_t next; // For chaining in the table
 };
 
-struct bs_file_table {
+typedef struct bs_file_table {
   bs_file_t head;
   bs_file_t* buckets;
   size_t bucket_count;
   size_t size;
   pthread_mutex_t lock; // Protects all table operations
-};
+} bs_file_table_t;
 
 struct bs_open_level_impl {
   bs_bsfs_t fs;
@@ -40,11 +40,11 @@ struct bs_bsfs_impl {
   bs_disk_t disk;
 };
 
-int bs_file_table_init(struct bs_file_table* table);
+int bs_file_table_init(bs_file_table_t* table);
 void bs_file_table_destroy(struct bs_file_table* table);
 
-int bs_file_table_open(struct bs_file_table* table, bft_offset_t off,
+int bs_file_table_open(bs_file_table_t* table, bft_offset_t off,
                        bs_file_t* file);
-int bs_file_table_release(struct bs_file_table* table, bs_file_t file);
+int bs_file_table_release(bs_file_table_t* table, bs_file_t file);
 
 #endif

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -29,7 +29,7 @@ struct bs_open_level_impl {
   char* pass;
   void* bft;
   void* bitmap;
-  // TODO: open_files
+  struct bs_file_table open_files;
   pthread_mutex_t ftab_lock;      // Protects open file table
   pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
 };

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -11,17 +11,17 @@ struct bs_file_impl {
 
   bft_offset_t index;
   atomic_int refcount;
-  pthread_rwlock_t lock; // Protects reads and writes to the file
+  pthread_rwlock_t lock; // protects reads and writes to the file
 
-  bs_file_t next; // For chaining in the table
+  bs_file_t next; // for chaining in the table
 };
 
 typedef struct bs_oft {
   bs_file_t head;
-  bs_file_t** buckets; // Array of next pointers
+  bs_file_t** buckets; // array of next pointers
   size_t bucket_count;
   size_t size;
-  pthread_mutex_t lock; // Protects all table operations
+  pthread_mutex_t lock; // protects all table operations
 } bs_oft_t;
 
 struct bs_open_level_impl {
@@ -31,12 +31,12 @@ struct bs_open_level_impl {
   void* bft;
   void* bitmap;
   bs_oft_t open_files;
-  pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
+  pthread_rwlock_t metadata_lock; // protects BFT and bitmap
 };
 
 struct bs_bsfs_impl {
   struct bs_open_level_impl levels[STEGO_USER_LEVEL_COUNT];
-  pthread_mutex_t level_lock; // Protects `levels`
+  pthread_mutex_t level_lock; // protects `levels`
   bs_disk_t disk;
 };
 

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -11,17 +11,17 @@ struct bs_file_impl {
 
   bft_offset_t index;
   atomic_int refcount;
-  pthread_rwlock_t lock; // protects reads and writes to the file
+  pthread_rwlock_t lock; // Protects reads and writes to the file
 
-  bs_file_t next; // for chaining in the table
+  bs_file_t next; // For chaining in the table
 };
 
 typedef struct bs_oft {
   bs_file_t head;
-  bs_file_t** buckets; // array of next pointers
+  bs_file_t** buckets; // Array of next pointers
   size_t bucket_count;
   size_t size;
-  pthread_mutex_t lock; // protects all table operations
+  pthread_mutex_t lock; // Protects all table operations
 } bs_oft_t;
 
 struct bs_open_level_impl {
@@ -31,12 +31,12 @@ struct bs_open_level_impl {
   void* bft;
   void* bitmap;
   bs_oft_t open_files;
-  pthread_rwlock_t metadata_lock; // protects BFT and bitmap
+  pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
 };
 
 struct bs_bsfs_impl {
   struct bs_open_level_impl levels[STEGO_USER_LEVEL_COUNT];
-  pthread_mutex_t level_lock; // protects `levels`
+  pthread_mutex_t level_lock; // Protects `levels`
   bs_disk_t disk;
 };
 

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -24,7 +24,7 @@ struct bs_file_table {
 };
 
 struct bs_open_level_impl {
-  bs_bsfs_t bsfs;
+  bs_bsfs_t fs;
   stego_key_t key;
   char* pass;
   void* bft;

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -21,6 +21,7 @@ struct bs_file_table {
   bs_file_t* buckets;
   size_t bucket_count;
   size_t size;
+  pthread_mutex_t lock; // Protects all table operations
 };
 
 struct bs_open_level_impl {
@@ -30,7 +31,6 @@ struct bs_open_level_impl {
   void* bft;
   void* bitmap;
   struct bs_file_table open_files;
-  pthread_mutex_t ftab_lock;      // Protects open file table
   pthread_rwlock_t metadata_lock; // Protects BFT and bitmap
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,14 +4,22 @@ pkg_check_modules(CHECK REQUIRED check)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/ ${CHECK_INCLUDE_DIR})
 
 set(TEST_SOURCES
-  test_bit_util.c
   test_bft.c
+  test_bft.h
+  test_bit_util.c
+  test_bit_util.h
   test_bsfs.c
+  test_bsfs.h
   test_cluster.c
-  test_enc.c
-  test_keytab.c
-  test_stego.c
+  test_cluster.h
   test_disk.c
+  test_disk.h
+  test_enc.c
+  test_enc.h
+  test_keytab.c
+  test_keytab.h
+  test_stego.c
+  test_stego.h
   test_vector.c
   main.c
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,21 +5,13 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/ ${CHECK_INCLUDE_DIR})
 
 set(TEST_SOURCES
   test_bft.c
-  test_bft.h
   test_bit_util.c
-  test_bit_util.h
   test_bsfs.c
-  test_bsfs.h
   test_cluster.c
-  test_cluster.h
   test_disk.c
-  test_disk.h
   test_enc.c
-  test_enc.h
   test_keytab.c
-  test_keytab.h
   test_stego.c
-  test_stego.h
   test_vector.c
   main.c
 )

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -95,6 +95,21 @@ START_TEST(test_ftab_insert_multi) {
 }
 END_TEST
 
+START_TEST(test_ftab_insert_multi_same_bucket) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
+                   0);
+  ck_assert_ptr_ne(file1, file2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 START_TEST(test_ftab_insert_multi_size) {
   bs_file_table_t table;
   ck_assert_int_eq(bs_file_table_init(&table), 0);
@@ -104,6 +119,29 @@ START_TEST(test_ftab_insert_multi_size) {
   bs_file_t file2;
   ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
   ck_assert_uint_eq(table.size, 2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_ftab_lookup_multi_same_bucket) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
+                   0);
+
+  bs_file_t found1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &found1), 0);
+  ck_assert_int_eq(found1->refcount, 2);
+
+  bs_file_t found2;
+  ck_assert_int_eq(
+      bs_file_table_open(&table, NULL, table.bucket_count, &found2), 0);
+  ck_assert_int_eq(found2->refcount, 2);
 
   bs_file_table_destroy(&table);
 }
@@ -165,7 +203,9 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_insert_size);
   tcase_add_test(ftab_tcase, test_ftab_insert_lookup_refcount);
   tcase_add_test(ftab_tcase, test_ftab_insert_multi);
+  tcase_add_test(ftab_tcase, test_ftab_insert_multi_same_bucket);
   tcase_add_test(ftab_tcase, test_ftab_insert_multi_size);
+  tcase_add_test(ftab_tcase, test_ftab_lookup_multi_same_bucket);
   tcase_add_test(ftab_tcase, test_ftab_insert_multi_rehash);
   tcase_add_test(ftab_tcase, test_ftab_insert_after_rehash);
   suite_add_tcase(suite, ftab_tcase);

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -252,26 +252,6 @@ START_TEST(test_oft_release_decref) {
 }
 END_TEST
 
-START_TEST(test_oft_remove_same_bucket) {
-  bs_oft_t table;
-  ck_assert_int_eq(bs_oft_init(&table), 0);
-
-  bs_file_t file1;
-  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
-
-  bs_file_t file2;
-  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
-
-  ck_assert_int_eq(bs_oft_release(&table, file1), 0);
-
-  bs_file_t file3;
-  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file3), 0);
-  ck_assert_int_eq(file3->refcount, 2);
-
-  bs_oft_destroy(&table);
-}
-END_TEST
-
 START_TEST(test_oft_remove_bucket_head) {
   bs_oft_t table;
   ck_assert_int_eq(bs_oft_init(&table), 0);
@@ -286,6 +266,26 @@ START_TEST(test_oft_remove_bucket_head) {
 
   bs_file_t file3;
   ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file3), 0);
+  ck_assert_int_eq(file3->refcount, 2);
+
+  bs_oft_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_oft_remove_bucket_tail) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
+
+  bs_file_t file2;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
+
+  ck_assert_int_eq(bs_oft_release(&table, file1), 0);
+
+  bs_file_t file3;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file3), 0);
   ck_assert_int_eq(file3->refcount, 2);
 
   bs_oft_destroy(&table);
@@ -336,8 +336,8 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_oft_remove_invalid);
   tcase_add_test(ftab_tcase, test_oft_remove_size);
   tcase_add_test(ftab_tcase, test_oft_release_decref);
-  tcase_add_test(ftab_tcase, test_oft_remove_same_bucket);
   tcase_add_test(ftab_tcase, test_oft_remove_bucket_head);
+  tcase_add_test(ftab_tcase, test_oft_remove_bucket_tail);
   tcase_add_test(ftab_tcase, test_oft_remove_other_bucket);
   suite_add_tcase(suite, ftab_tcase);
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -231,6 +231,20 @@ START_TEST(test_ftab_remove_size) {
 }
 END_TEST
 
+START_TEST(test_ftab_release_decref) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_file_table_release(&table, file), 0);
+  ck_assert_int_eq(file->refcount, 1);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
@@ -248,6 +262,7 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_insert_after_rehash);
   tcase_add_test(ftab_tcase, test_ftab_remove_empty);
   tcase_add_test(ftab_tcase, test_ftab_remove_size);
+  tcase_add_test(ftab_tcase, test_ftab_release_decref);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -201,6 +201,36 @@ START_TEST(test_ftab_insert_after_rehash) {
 }
 END_TEST
 
+START_TEST(test_ftab_remove_empty) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_file_table_release(&table, file), 0);
+
+  ck_assert_ptr_eq(table.head, NULL);
+  for (size_t i = 0; i < table.bucket_count; i++) {
+    ck_assert_ptr_eq(table.buckets[i], NULL);
+  }
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_ftab_remove_size) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_file_table_release(&table, file), 0);
+  ck_assert_int_eq(table.size, 0);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
@@ -216,6 +246,8 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_lookup_multi_same_bucket);
   tcase_add_test(ftab_tcase, test_ftab_rehash);
   tcase_add_test(ftab_tcase, test_ftab_insert_after_rehash);
+  tcase_add_test(ftab_tcase, test_ftab_remove_empty);
+  tcase_add_test(ftab_tcase, test_ftab_remove_size);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -147,7 +147,7 @@ START_TEST(test_ftab_lookup_multi_same_bucket) {
 }
 END_TEST
 
-START_TEST(test_ftab_insert_multi_rehash) {
+START_TEST(test_ftab_rehash) {
   bs_file_table_t table;
   ck_assert_int_eq(bs_file_table_init(&table), 0);
 
@@ -206,7 +206,7 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_insert_multi_same_bucket);
   tcase_add_test(ftab_tcase, test_ftab_insert_multi_size);
   tcase_add_test(ftab_tcase, test_ftab_lookup_multi_same_bucket);
-  tcase_add_test(ftab_tcase, test_ftab_insert_multi_rehash);
+  tcase_add_test(ftab_tcase, test_ftab_rehash);
   tcase_add_test(ftab_tcase, test_ftab_insert_after_rehash);
   suite_add_tcase(suite, ftab_tcase);
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -300,6 +300,31 @@ START_TEST(test_ftab_remove_bucket_head) {
 }
 END_TEST
 
+START_TEST(test_ftab_remove_other_bucket) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
+  bs_file_t file3;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 2, &file3), 0);
+
+  ck_assert_int_eq(bs_file_table_release(&table, file2), 0);
+
+  bs_file_t found1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &found1), 0);
+  ck_assert_int_eq(found1->refcount, 2);
+
+  bs_file_t found3;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 2, &found3), 0);
+  ck_assert_int_eq(found3->refcount, 2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
@@ -321,6 +346,7 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_release_decref);
   tcase_add_test(ftab_tcase, test_ftab_remove_same_bucket);
   tcase_add_test(ftab_tcase, test_ftab_remove_bucket_head);
+  tcase_add_test(ftab_tcase, test_ftab_remove_other_bucket);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -272,6 +272,34 @@ START_TEST(test_oft_remove_bucket_head) {
 }
 END_TEST
 
+START_TEST(test_oft_remove_bucket_mid) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
+
+  bs_file_t file2;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
+
+  bs_file_t file3;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 2 * table.bucket_count, &file3), 0);
+
+  ck_assert_int_eq(bs_oft_release(&table, file2), 0);
+
+  bs_file_t found1;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &found1), 0);
+  ck_assert_int_eq(found1->refcount, 2);
+
+  bs_file_t found3;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 2 * table.bucket_count, &found3),
+                   0);
+  ck_assert_int_eq(found3->refcount, 2);
+
+  bs_oft_destroy(&table);
+}
+END_TEST
+
 START_TEST(test_oft_remove_bucket_tail) {
   bs_oft_t table;
   ck_assert_int_eq(bs_oft_init(&table), 0);
@@ -337,6 +365,7 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_oft_remove_size);
   tcase_add_test(ftab_tcase, test_oft_release_decref);
   tcase_add_test(ftab_tcase, test_oft_remove_bucket_head);
+  tcase_add_test(ftab_tcase, test_oft_remove_bucket_mid);
   tcase_add_test(ftab_tcase, test_oft_remove_bucket_tail);
   tcase_add_test(ftab_tcase, test_oft_remove_other_bucket);
   suite_add_tcase(suite, ftab_tcase);

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -1,16 +1,40 @@
 #include "test_bsfs.h"
 
-START_TEST(test_example) {
-  ck_assert_int_eq(3, 3);
+#include "bsfs_priv.h"
+
+START_TEST(test_ftab_insert_lookup) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t created;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &created), 0);
+  bs_file_t found;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &found), 0);
+  ck_assert_ptr_eq(created, found);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_ftab_insert_size) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
+  ck_assert_uint_eq(table.size, 1);
+
+  bs_file_table_destroy(&table);
 }
 END_TEST
 
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
-  TCase* example_tcase = tcase_create("example");
 
-  tcase_add_test(example_tcase, test_example);
-  suite_add_tcase(suite, example_tcase);
+  TCase* ftab_tcase = tcase_create("ftab");
+  tcase_add_test(ftab_tcase, test_ftab_insert_lookup);
+  tcase_add_test(ftab_tcase, test_ftab_insert_size);
+  suite_add_tcase(suite, ftab_tcase);
 
   return suite;
 }

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -28,12 +28,30 @@ START_TEST(test_ftab_insert_size) {
 }
 END_TEST
 
+START_TEST(test_ftab_insert_lookup_refcount) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file1), 0);
+  ck_assert_int_eq(file1->refcount, 1);
+
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file2), 0);
+  ck_assert_ptr_eq(file1, file2);
+  ck_assert_int_eq(file2->refcount, 2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
   TCase* ftab_tcase = tcase_create("ftab");
   tcase_add_test(ftab_tcase, test_ftab_insert_lookup);
   tcase_add_test(ftab_tcase, test_ftab_insert_size);
+  tcase_add_test(ftab_tcase, test_ftab_insert_lookup_refcount);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -1,6 +1,7 @@
 #include "test_bsfs.h"
 
 #include "bsfs_priv.h"
+#include <errno.h>
 
 START_TEST(test_ftab_insert_vals) {
   bs_file_table_t table;
@@ -218,6 +219,17 @@ START_TEST(test_ftab_remove_empty) {
 }
 END_TEST
 
+START_TEST(test_ftab_remove_invalid) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  struct bs_file_impl raw_file = { .refcount = 1 };
+  ck_assert_int_eq(bs_file_table_release(&table, &raw_file), -EINVAL);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 START_TEST(test_ftab_remove_size) {
   bs_file_table_t table;
   ck_assert_int_eq(bs_file_table_init(&table), 0);
@@ -304,6 +316,7 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_rehash);
   tcase_add_test(ftab_tcase, test_ftab_insert_after_rehash);
   tcase_add_test(ftab_tcase, test_ftab_remove_empty);
+  tcase_add_test(ftab_tcase, test_ftab_remove_invalid);
   tcase_add_test(ftab_tcase, test_ftab_remove_size);
   tcase_add_test(ftab_tcase, test_ftab_release_decref);
   tcase_add_test(ftab_tcase, test_ftab_remove_same_bucket);

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -45,6 +45,34 @@ START_TEST(test_ftab_insert_lookup_refcount) {
 }
 END_TEST
 
+START_TEST(test_ftab_insert_multi) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
+  ck_assert_ptr_ne(file1, file2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_ftab_insert_multi_size) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
+  ck_assert_uint_eq(table.size, 2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
@@ -52,6 +80,8 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_insert_lookup);
   tcase_add_test(ftab_tcase, test_ftab_insert_size);
   tcase_add_test(ftab_tcase, test_ftab_insert_lookup_refcount);
+  tcase_add_test(ftab_tcase, test_ftab_insert_multi);
+  tcase_add_test(ftab_tcase, test_ftab_insert_multi_size);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -158,12 +158,20 @@ START_TEST(test_ftab_rehash) {
   for (; table.bucket_count == initial_bucket_count; i++) {
     bs_file_t file;
     ck_assert_int_eq(bs_file_table_open(&table, NULL, i, &file), 0);
+    ck_assert_int_eq(
+        bs_file_table_open(&table, NULL, i + 2 * initial_bucket_count, &file),
+        0);
   }
 
   // verify contents
   for (i--; i >= 0; i--) {
     bs_file_t file;
     ck_assert_int_eq(bs_file_table_open(&table, NULL, i, &file), 0);
+    ck_assert_int_eq(file->refcount, 2);
+
+    ck_assert_int_eq(
+        bs_file_table_open(&table, NULL, i + 2 * initial_bucket_count, &file),
+        0);
     ck_assert_int_eq(file->refcount, 2);
   }
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -3,154 +3,151 @@
 #include "bsfs_priv.h"
 #include <errno.h>
 
-START_TEST(test_ftab_insert_vals) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_vals) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   struct bs_open_level_impl* const level =
       (struct bs_open_level_impl*) 0xdeadbeef;
   const bft_offset_t index = 123;
 
   bs_file_t file;
-  ck_assert_int_eq(bs_file_table_open(&table, level, index, &file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, level, index, &file), 0);
   ck_assert_ptr_eq(file->level, level);
   ck_assert_int_eq(file->index, index);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_lookup) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_lookup) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t created;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &created), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &created), 0);
   bs_file_t found;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &found), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &found), 0);
   ck_assert_ptr_eq(created, found);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_lookup_vals) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_lookup_vals) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   struct bs_open_level_impl* const level =
       (struct bs_open_level_impl*) 0xdeadbeef;
   const bft_offset_t index = 123;
 
   bs_file_t created;
-  ck_assert_int_eq(bs_file_table_open(&table, level, index, &created), 0);
+  ck_assert_int_eq(bs_oft_get(&table, level, index, &created), 0);
   bs_file_t found;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, index, &found), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, index, &found), 0);
 
   ck_assert_ptr_eq(found->level, level);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_size) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_size) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file), 0);
   ck_assert_uint_eq(table.size, 1);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_lookup_refcount) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_lookup_refcount) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file1), 0);
   ck_assert_int_eq(file1->refcount, 1);
 
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file2), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file2), 0);
   ck_assert_ptr_eq(file1, file2);
   ck_assert_int_eq(file2->refcount, 2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_multi) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_multi) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 1, &file2), 0);
   ck_assert_ptr_ne(file1, file2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_multi_same_bucket) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_multi_same_bucket) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
-                   0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
   ck_assert_ptr_ne(file1, file2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_multi_size) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_multi_size) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 1, &file2), 0);
   ck_assert_uint_eq(table.size, 2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_lookup_multi_same_bucket) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_lookup_multi_same_bucket) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
-                   0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
 
   bs_file_t found1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &found1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &found1), 0);
   ck_assert_int_eq(found1->refcount, 2);
 
   bs_file_t found2;
-  ck_assert_int_eq(
-      bs_file_table_open(&table, NULL, table.bucket_count, &found2), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &found2), 0);
   ck_assert_int_eq(found2->refcount, 2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_rehash) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_rehash) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   size_t initial_bucket_count = table.bucket_count;
   bft_offset_t i = 0;
@@ -158,31 +155,29 @@ START_TEST(test_ftab_rehash) {
   // wait for rehash
   for (; table.bucket_count == initial_bucket_count; i++) {
     bs_file_t file;
-    ck_assert_int_eq(bs_file_table_open(&table, NULL, i, &file), 0);
+    ck_assert_int_eq(bs_oft_get(&table, NULL, i, &file), 0);
     ck_assert_int_eq(
-        bs_file_table_open(&table, NULL, i + 2 * initial_bucket_count, &file),
-        0);
+        bs_oft_get(&table, NULL, i + 2 * initial_bucket_count, &file), 0);
   }
 
   // verify contents
   for (i--; i >= 0; i--) {
     bs_file_t file;
-    ck_assert_int_eq(bs_file_table_open(&table, NULL, i, &file), 0);
+    ck_assert_int_eq(bs_oft_get(&table, NULL, i, &file), 0);
     ck_assert_int_eq(file->refcount, 2);
 
     ck_assert_int_eq(
-        bs_file_table_open(&table, NULL, i + 2 * initial_bucket_count, &file),
-        0);
+        bs_oft_get(&table, NULL, i + 2 * initial_bucket_count, &file), 0);
     ck_assert_int_eq(file->refcount, 2);
   }
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_insert_after_rehash) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_insert_after_rehash) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   size_t initial_bucket_count = table.bucket_count;
   bft_offset_t i = 0;
@@ -190,138 +185,135 @@ START_TEST(test_ftab_insert_after_rehash) {
   // wait for rehash
   for (; table.bucket_count == initial_bucket_count; i++) {
     bs_file_t file;
-    ck_assert_int_eq(bs_file_table_open(&table, NULL, i, &file), 0);
+    ck_assert_int_eq(bs_oft_get(&table, NULL, i, &file), 0);
   }
 
   // insert new file
   bs_file_t file;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, i, &file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, i, &file), 0);
   ck_assert_int_eq(file->refcount, 1);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_remove_empty) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_remove_empty) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
-  ck_assert_int_eq(bs_file_table_release(&table, file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_oft_release(&table, file), 0);
 
   ck_assert_ptr_eq(table.head, NULL);
   for (size_t i = 0; i < table.bucket_count; i++) {
     ck_assert_ptr_eq(table.buckets[i], NULL);
   }
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_remove_invalid) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_remove_invalid) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   struct bs_file_impl raw_file = { .refcount = 1 };
-  ck_assert_int_eq(bs_file_table_release(&table, &raw_file), -EINVAL);
+  ck_assert_int_eq(bs_oft_release(&table, &raw_file), -EINVAL);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_remove_size) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_remove_size) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
-  ck_assert_int_eq(bs_file_table_release(&table, file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_oft_release(&table, file), 0);
   ck_assert_int_eq(table.size, 0);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_release_decref) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_release_decref) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &file), 0);
-  ck_assert_int_eq(bs_file_table_release(&table, file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file), 0);
+  ck_assert_int_eq(bs_oft_release(&table, file), 0);
   ck_assert_int_eq(file->refcount, 1);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_remove_same_bucket) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_remove_same_bucket) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
 
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
-                   0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
 
-  ck_assert_int_eq(bs_file_table_release(&table, file1), 0);
+  ck_assert_int_eq(bs_oft_release(&table, file1), 0);
 
   bs_file_t file3;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file3),
-                   0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file3), 0);
   ck_assert_int_eq(file3->refcount, 2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_remove_bucket_head) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_remove_bucket_head) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
 
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
-                   0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file2), 0);
 
-  ck_assert_int_eq(bs_file_table_release(&table, file2), 0);
+  ck_assert_int_eq(bs_oft_release(&table, file2), 0);
 
   bs_file_t file3;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file3), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file3), 0);
   ck_assert_int_eq(file3->refcount, 2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
-START_TEST(test_ftab_remove_other_bucket) {
-  bs_file_table_t table;
-  ck_assert_int_eq(bs_file_table_init(&table), 0);
+START_TEST(test_oft_remove_other_bucket) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
 
   bs_file_t file1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file1), 0);
   bs_file_t file2;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 1, &file2), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 1, &file2), 0);
   bs_file_t file3;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 2, &file3), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 2, &file3), 0);
 
-  ck_assert_int_eq(bs_file_table_release(&table, file2), 0);
+  ck_assert_int_eq(bs_oft_release(&table, file2), 0);
 
   bs_file_t found1;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &found1), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &found1), 0);
   ck_assert_int_eq(found1->refcount, 2);
 
   bs_file_t found3;
-  ck_assert_int_eq(bs_file_table_open(&table, NULL, 2, &found3), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 2, &found3), 0);
   ck_assert_int_eq(found3->refcount, 2);
 
-  bs_file_table_destroy(&table);
+  bs_oft_destroy(&table);
 }
 END_TEST
 
@@ -329,24 +321,24 @@ Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
   TCase* ftab_tcase = tcase_create("ftab");
-  tcase_add_test(ftab_tcase, test_ftab_insert_vals);
-  tcase_add_test(ftab_tcase, test_ftab_insert_lookup);
-  tcase_add_test(ftab_tcase, test_ftab_insert_lookup_vals);
-  tcase_add_test(ftab_tcase, test_ftab_insert_size);
-  tcase_add_test(ftab_tcase, test_ftab_insert_lookup_refcount);
-  tcase_add_test(ftab_tcase, test_ftab_insert_multi);
-  tcase_add_test(ftab_tcase, test_ftab_insert_multi_same_bucket);
-  tcase_add_test(ftab_tcase, test_ftab_insert_multi_size);
-  tcase_add_test(ftab_tcase, test_ftab_lookup_multi_same_bucket);
-  tcase_add_test(ftab_tcase, test_ftab_rehash);
-  tcase_add_test(ftab_tcase, test_ftab_insert_after_rehash);
-  tcase_add_test(ftab_tcase, test_ftab_remove_empty);
-  tcase_add_test(ftab_tcase, test_ftab_remove_invalid);
-  tcase_add_test(ftab_tcase, test_ftab_remove_size);
-  tcase_add_test(ftab_tcase, test_ftab_release_decref);
-  tcase_add_test(ftab_tcase, test_ftab_remove_same_bucket);
-  tcase_add_test(ftab_tcase, test_ftab_remove_bucket_head);
-  tcase_add_test(ftab_tcase, test_ftab_remove_other_bucket);
+  tcase_add_test(ftab_tcase, test_oft_insert_vals);
+  tcase_add_test(ftab_tcase, test_oft_insert_lookup);
+  tcase_add_test(ftab_tcase, test_oft_insert_lookup_vals);
+  tcase_add_test(ftab_tcase, test_oft_insert_size);
+  tcase_add_test(ftab_tcase, test_oft_insert_lookup_refcount);
+  tcase_add_test(ftab_tcase, test_oft_insert_multi);
+  tcase_add_test(ftab_tcase, test_oft_insert_multi_same_bucket);
+  tcase_add_test(ftab_tcase, test_oft_insert_multi_size);
+  tcase_add_test(ftab_tcase, test_oft_lookup_multi_same_bucket);
+  tcase_add_test(ftab_tcase, test_oft_rehash);
+  tcase_add_test(ftab_tcase, test_oft_insert_after_rehash);
+  tcase_add_test(ftab_tcase, test_oft_remove_empty);
+  tcase_add_test(ftab_tcase, test_oft_remove_invalid);
+  tcase_add_test(ftab_tcase, test_oft_remove_size);
+  tcase_add_test(ftab_tcase, test_oft_release_decref);
+  tcase_add_test(ftab_tcase, test_oft_remove_same_bucket);
+  tcase_add_test(ftab_tcase, test_oft_remove_bucket_head);
+  tcase_add_test(ftab_tcase, test_oft_remove_other_bucket);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -2,6 +2,23 @@
 
 #include "bsfs_priv.h"
 
+START_TEST(test_ftab_insert_vals) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  struct bs_open_level_impl* const level =
+      (struct bs_open_level_impl*) 0xdeadbeef;
+  const bft_offset_t index = 123;
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_file_table_open(&table, level, index, &file), 0);
+  ck_assert_ptr_eq(file->level, level);
+  ck_assert_int_eq(file->index, index);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 START_TEST(test_ftab_insert_lookup) {
   bs_file_table_t table;
   ck_assert_int_eq(bs_file_table_init(&table), 0);
@@ -11,6 +28,25 @@ START_TEST(test_ftab_insert_lookup) {
   bs_file_t found;
   ck_assert_int_eq(bs_file_table_open(&table, NULL, 123, &found), 0);
   ck_assert_ptr_eq(created, found);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_ftab_insert_lookup_vals) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  struct bs_open_level_impl* const level =
+      (struct bs_open_level_impl*) 0xdeadbeef;
+  const bft_offset_t index = 123;
+
+  bs_file_t created;
+  ck_assert_int_eq(bs_file_table_open(&table, level, index, &created), 0);
+  bs_file_t found;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, index, &found), 0);
+
+  ck_assert_ptr_eq(found->level, level);
 
   bs_file_table_destroy(&table);
 }
@@ -77,7 +113,9 @@ Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
   TCase* ftab_tcase = tcase_create("ftab");
+  tcase_add_test(ftab_tcase, test_ftab_insert_vals);
   tcase_add_test(ftab_tcase, test_ftab_insert_lookup);
+  tcase_add_test(ftab_tcase, test_ftab_insert_lookup_vals);
   tcase_add_test(ftab_tcase, test_ftab_insert_size);
   tcase_add_test(ftab_tcase, test_ftab_insert_lookup_refcount);
   tcase_add_test(ftab_tcase, test_ftab_insert_multi);

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -245,6 +245,49 @@ START_TEST(test_ftab_release_decref) {
 }
 END_TEST
 
+START_TEST(test_ftab_remove_same_bucket) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
+                   0);
+
+  ck_assert_int_eq(bs_file_table_release(&table, file1), 0);
+
+  bs_file_t file3;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file3),
+                   0);
+  ck_assert_int_eq(file3->refcount, 2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_ftab_remove_bucket_head) {
+  bs_file_table_t table;
+  ck_assert_int_eq(bs_file_table_init(&table), 0);
+
+  bs_file_t file1;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file1), 0);
+
+  bs_file_t file2;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, table.bucket_count, &file2),
+                   0);
+
+  ck_assert_int_eq(bs_file_table_release(&table, file2), 0);
+
+  bs_file_t file3;
+  ck_assert_int_eq(bs_file_table_open(&table, NULL, 0, &file3), 0);
+  ck_assert_int_eq(file3->refcount, 2);
+
+  bs_file_table_destroy(&table);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
@@ -263,6 +306,8 @@ Suite* bsfs_suite(void) {
   tcase_add_test(ftab_tcase, test_ftab_remove_empty);
   tcase_add_test(ftab_tcase, test_ftab_remove_size);
   tcase_add_test(ftab_tcase, test_ftab_release_decref);
+  tcase_add_test(ftab_tcase, test_ftab_remove_same_bucket);
+  tcase_add_test(ftab_tcase, test_ftab_remove_bucket_head);
   suite_add_tcase(suite, ftab_tcase);
 
   return suite;


### PR DESCRIPTION
In order to unit test this internal structure effectively, a new header declaring private BSFS structures was created. While not intended for external use, it gives the unit tests access to the definition of the OFT and its operations.