### PR TITLE
Fix year 2038 problem

### DIFF
--- a/src/bft.c
+++ b/src/bft.c
@@ -48,19 +48,19 @@ static int do_read_entry(const uint8_t* raw_ent, bft_entry_t* ent) {
   ent->name = (const char*) raw_ent;
   raw_ent += BFT_MAX_FILENAME;
 
-  ent->initial_cluster = read_big_endian(raw_ent);
+  ent->initial_cluster = read_be32(raw_ent);
   raw_ent += sizeof(uint32_t);
 
-  ent->size = read_big_endian(raw_ent);
+  ent->size = read_be32(raw_ent);
   raw_ent += sizeof(uint32_t);
 
-  ent->mode = read_big_endian(raw_ent);
+  ent->mode = read_be32(raw_ent);
   raw_ent += sizeof(uint32_t);
 
-  ent->atim = read_big_endian(raw_ent);
+  ent->atim = read_be32(raw_ent);
   raw_ent += sizeof(uint32_t);
 
-  ent->mtim = read_big_endian(raw_ent);
+  ent->mtim = read_be32(raw_ent);
   return 0;
 }
 
@@ -72,19 +72,19 @@ static int do_write_entry(uint8_t* raw_ent, const bft_entry_t* ent) {
   strncpy((char*) raw_ent, ent->name, BFT_MAX_FILENAME);
   raw_ent += BFT_MAX_FILENAME;
 
-  write_big_endian(raw_ent, ent->initial_cluster);
+  write_be32(raw_ent, ent->initial_cluster);
   raw_ent += sizeof(uint32_t);
 
-  write_big_endian(raw_ent, ent->size);
+  write_be32(raw_ent, ent->size);
   raw_ent += sizeof(uint32_t);
 
-  write_big_endian(raw_ent, ent->mode);
+  write_be32(raw_ent, ent->mode);
   raw_ent += sizeof(uint32_t);
 
-  write_big_endian(raw_ent, ent->atim);
+  write_be32(raw_ent, ent->atim);
   raw_ent += sizeof(uint32_t);
 
-  write_big_endian(raw_ent, ent->mtim);
+  write_be32(raw_ent, ent->mtim);
   return 0;
 }
 

--- a/src/bft.c
+++ b/src/bft.c
@@ -57,10 +57,10 @@ static int do_read_entry(const uint8_t* raw_ent, bft_entry_t* ent) {
   ent->mode = read_be32(raw_ent);
   raw_ent += sizeof(uint32_t);
 
-  ent->atim = read_be32(raw_ent);
-  raw_ent += sizeof(uint32_t);
+  ent->atim = read_be64(raw_ent);
+  raw_ent += sizeof(bft_timestamp_t);
 
-  ent->mtim = read_be32(raw_ent);
+  ent->mtim = read_be64(raw_ent);
   return 0;
 }
 
@@ -81,10 +81,10 @@ static int do_write_entry(uint8_t* raw_ent, const bft_entry_t* ent) {
   write_be32(raw_ent, ent->mode);
   raw_ent += sizeof(uint32_t);
 
-  write_be32(raw_ent, ent->atim);
-  raw_ent += sizeof(uint32_t);
+  write_be64(raw_ent, ent->atim);
+  raw_ent += sizeof(bft_timestamp_t);
 
-  write_be32(raw_ent, ent->mtim);
+  write_be64(raw_ent, ent->mtim);
   return 0;
 }
 

--- a/src/bft.h
+++ b/src/bft.h
@@ -10,11 +10,14 @@
 #include <sys/types.h>
 
 #define BFT_MAX_FILENAME 64
-#define BFT_ENTRY_SIZE 84 // 64B + 5 * 4B
+#define BFT_ENTRY_SIZE                                                         \
+  (BFT_MAX_FILENAME + sizeof(cluster_offset_t) +                               \
+   2 * sizeof(uint32_t) /* size, mode */ +                                     \
+   2 * sizeof(bft_timestamp_t) /* atim, mtim */)
 #define BFT_MAX_ENTRIES 8192
 #define BFT_SIZE (BFT_ENTRY_SIZE * BFT_MAX_ENTRIES)
 
-typedef uint32_t bft_timestamp_t;
+typedef uint64_t bft_timestamp_t;
 typedef int16_t bft_offset_t;
 
 typedef struct bft_entry {

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -1,18 +1,29 @@
 #include "bit_util.h"
 
-#include <arpa/inet.h>
+#include <endian.h>
 #include <limits.h>
 #include <string.h>
 
 uint32_t read_be32(const void* buf) {
   uint32_t big_endian;
   memcpy(&big_endian, buf, sizeof(uint32_t));
-  return ntohl(big_endian);
+  return be32toh(big_endian);
 }
 
 void write_be32(void* buf, uint32_t host_endian) {
-  uint32_t big_endian = htonl(host_endian);
+  uint32_t big_endian = htobe32(host_endian);
   memcpy(buf, &big_endian, sizeof(uint32_t));
+}
+
+uint64_t read_be64(const void* buf) {
+  uint64_t big_endian;
+  memcpy(&big_endian, buf, sizeof(uint64_t));
+  return be64toh(big_endian);
+}
+
+void write_be64(void* buf, uint64_t host_endian) {
+  uint64_t big_endian = htobe64(host_endian);
+  memcpy(buf, &big_endian, sizeof(uint64_t));
 }
 
 static size_t byte_from_bit(size_t bit) {

--- a/src/bit_util.c
+++ b/src/bit_util.c
@@ -4,13 +4,13 @@
 #include <limits.h>
 #include <string.h>
 
-uint32_t read_big_endian(const void* buf) {
+uint32_t read_be32(const void* buf) {
   uint32_t big_endian;
   memcpy(&big_endian, buf, sizeof(uint32_t));
   return ntohl(big_endian);
 }
 
-void write_big_endian(void* buf, uint32_t host_endian) {
+void write_be32(void* buf, uint32_t host_endian) {
   uint32_t big_endian = htonl(host_endian);
   memcpy(buf, &big_endian, sizeof(uint32_t));
 }

--- a/src/bit_util.h
+++ b/src/bit_util.h
@@ -5,8 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-uint32_t read_big_endian(const void* buf);
-void write_big_endian(void* buf, uint32_t host_endian);
+uint32_t read_be32(const void* buf);
+void write_be32(void* buf, uint32_t host_endian);
 
 bool get_bit(const void* buf, size_t bit);
 void set_bit(void* buf, size_t bit, bool val);

--- a/src/bit_util.h
+++ b/src/bit_util.h
@@ -8,6 +8,9 @@
 uint32_t read_be32(const void* buf);
 void write_be32(void* buf, uint32_t host_endian);
 
+uint64_t read_be64(const void* buf);
+void write_be64(void* buf, uint64_t host_endian);
+
 bool get_bit(const void* buf, size_t bit);
 void set_bit(void* buf, size_t bit, bool val);
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -47,11 +47,11 @@ int fs_write_cluster(const stego_key_t* key, bs_disk_t disk, const void* buf,
 }
 
 cluster_offset_t fs_next_cluster(const void* cluster) {
-  return read_big_endian((const uint8_t*) cluster + CLUSTER_DATA_SIZE);
+  return read_be32((const uint8_t*) cluster + CLUSTER_DATA_SIZE);
 }
 
 void fs_set_next_cluster(void* cluster, cluster_offset_t next) {
-  write_big_endian((uint8_t*) cluster + CLUSTER_DATA_SIZE, next);
+  write_be32((uint8_t*) cluster + CLUSTER_DATA_SIZE, next);
 }
 
 int fs_read_bitmap(const stego_key_t* key, bs_disk_t disk, void* buf) {

--- a/tests/test_bft.c
+++ b/tests/test_bft.c
@@ -60,7 +60,9 @@ START_TEST(test_bft_entry_roundtrip) {
   uint8_t bft[BFT_SIZE];
 
   bft_entry_t original;
-  ck_assert_int_eq(bft_entry_init(&original, "file", 1024, 0, 1, 0, 0), 0);
+  ck_assert_int_eq(bft_entry_init(&original, "file", 1024, 0, 1,
+                                  0xdeadbeeff00df00d, 0xdeadbeefcafedead),
+                   0);
 
   int write_status = bft_write_table_entry(bft, &original, 0);
   ck_assert_int_eq(write_status, 0);

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -3,19 +3,19 @@
 #include "bit_util.h"
 #include <string.h>
 
-START_TEST(test_write_big_endian) {
+START_TEST(test_write_be32) {
   uint32_t val = 0xdeadbeef;
   uint8_t expected[] = { 0xde, 0xad, 0xbe, 0xef };
 
   uint8_t buf[sizeof(uint32_t)];
-  write_big_endian(buf, val);
+  write_be32(buf, val);
   ck_assert_int_eq(memcmp(buf, expected, sizeof(uint32_t)), 0);
 }
 END_TEST
 
-START_TEST(test_read_big_endian) {
+START_TEST(test_read_be32) {
   uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef };
-  ck_assert_uint_eq(read_big_endian(buf), 0xdeadbeef);
+  ck_assert_uint_eq(read_be32(buf), 0xdeadbeef);
 }
 END_TEST
 
@@ -50,8 +50,8 @@ Suite* bit_util_suite(void) {
   Suite* suite = suite_create("bit_util");
 
   TCase* endian_tcase = tcase_create("endian");
-  tcase_add_test(endian_tcase, test_write_big_endian);
-  tcase_add_test(endian_tcase, test_read_big_endian);
+  tcase_add_test(endian_tcase, test_write_be32);
+  tcase_add_test(endian_tcase, test_read_be32);
   suite_add_tcase(suite, endian_tcase);
 
   TCase* bit_tcase = tcase_create("bits");

--- a/tests/test_bit_util.c
+++ b/tests/test_bit_util.c
@@ -19,6 +19,22 @@ START_TEST(test_read_be32) {
 }
 END_TEST
 
+START_TEST(test_write_be64) {
+  uint64_t val = 0xdeadbeefcafedead;
+  uint8_t expected[] = { 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xde, 0xad };
+
+  uint8_t buf[sizeof(uint64_t)];
+  write_be64(buf, val);
+  ck_assert_int_eq(memcmp(buf, expected, sizeof(uint64_t)), 0);
+}
+END_TEST
+
+START_TEST(test_read_be64) {
+  uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xde, 0xad };
+  ck_assert_uint_eq(read_be64(buf), 0xdeadbeefcafedead);
+}
+END_TEST
+
 START_TEST(test_set_bit) {
   uint8_t buf[] = { 0xde, 0xad, 0xbe, 0xef };
   set_bit(buf, 7, 1);
@@ -52,6 +68,8 @@ Suite* bit_util_suite(void) {
   TCase* endian_tcase = tcase_create("endian");
   tcase_add_test(endian_tcase, test_write_be32);
   tcase_add_test(endian_tcase, test_read_be32);
+  tcase_add_test(endian_tcase, test_write_be64);
+  tcase_add_test(endian_tcase, test_read_be64);
   suite_add_tcase(suite, endian_tcase);
 
   TCase* bit_tcase = tcase_create("bits");


### PR DESCRIPTION
Currently, the BFT uses 32-bit timestamps, which means they will wrap around at 2038. This PR makes timestamps 64-bit, which should be adequate for the rest of the foreseeable (and unforeseeable) future.