### PR TITLE
Implement getattr

### DIFF
--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -447,8 +447,9 @@ int bsfs_fsync(bs_file_t file, bool datasync) {
 }
 
 static void stat_from_bft_ent(struct stat* st, const bft_entry_t* ent) {
-  *st = (struct stat){ .st_size = ent->size,
+  *st = (struct stat){ .st_nlink = 1,
                        .st_mode = ent->mode,
+                       .st_size = ent->size,
                        .st_atim.tv_sec = ent->atim,
                        .st_mtim.tv_sec = ent->mtim };
 }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -454,8 +454,8 @@ static void stat_from_bft_ent(struct stat* st, const bft_entry_t* ent) {
                        .st_mtim.tv_sec = ent->mtim };
 }
 
-static int getattr_common(bs_open_level_t level, bft_offset_t index,
-                          struct stat* st) {
+static int do_getattr(bs_open_level_t level, bft_offset_t index,
+                      struct stat* st) {
   bft_entry_t ent;
   int ret = bft_read_table_entry(level->bft, &ent, index);
   if (ret < 0) {
@@ -475,7 +475,7 @@ int bsfs_getattr(bs_bsfs_t fs, const char* path, struct stat* st) {
     return ret;
   }
 
-  ret = getattr_common(level, index, st);
+  ret = do_getattr(level, index, st);
 
   pthread_rwlock_unlock(&level->metadata_lock);
   return ret;
@@ -489,7 +489,7 @@ int bsfs_fgetattr(bs_file_t file, struct stat* st) {
     return ret;
   }
 
-  ret = getattr_common(level, file->index, st);
+  ret = do_getattr(level, file->index, st);
 
   pthread_rwlock_unlock(&level->metadata_lock);
   return ret;

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -454,14 +454,6 @@ int bsfs_fgetattr(bs_file_t file, struct stat* st) {
   return -ENOSYS;
 }
 
-int bsfs_setattr(bs_bsfs_t fs, const char* path, const struct stat* st) {
-  return -ENOSYS;
-}
-
-int bsfs_fsetattr(bs_file_t file, const struct stat* st) {
-  return -ENOSYS;
-}
-
 int bsfs_chmod(bs_bsfs_t fs, const char* path, mode_t mode) {
   return -ENOSYS;
 }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -238,17 +238,6 @@ cleanup:
   return ret;
 }
 
-static size_t count_clusters_from_disk(bs_disk_t disk) {
-  return fs_count_clusters(stego_compute_user_level_size(disk_get_size(disk)));
-}
-
-static void stat_from_bft_ent(struct stat* st, const bft_entry_t* ent) {
-  *st = (struct stat){ .st_size = ent->size,
-                       .st_mode = ent->mode,
-                       .st_atim.tv_sec = ent->atim,
-                       .st_mtim.tv_sec = ent->mtim };
-}
-
 int bsfs_init(int fd, bs_bsfs_t* out) {
   bs_bsfs_t fs = calloc(1, sizeof(*fs));
   if (!fs) {
@@ -296,6 +285,10 @@ void bsfs_destroy(bs_bsfs_t fs) {
   pthread_mutex_destroy(&fs->level_lock);
   disk_free(fs->disk);
   free(fs);
+}
+
+static size_t count_clusters_from_disk(bs_disk_t disk) {
+  return fs_count_clusters(stego_compute_user_level_size(disk_get_size(disk)));
 }
 
 int bsfs_mknod(bs_bsfs_t fs, const char* path, mode_t mode) {
@@ -451,6 +444,13 @@ int bsfs_fsync(bs_file_t file, bool datasync) {
     return level_flush_metadata(file->level);
   }
   return 0;
+}
+
+static void stat_from_bft_ent(struct stat* st, const bft_entry_t* ent) {
+  *st = (struct stat){ .st_size = ent->size,
+                       .st_mode = ent->mode,
+                       .st_atim.tv_sec = ent->atim,
+                       .st_mtim.tv_sec = ent->mtim };
 }
 
 static int getattr_common(bs_open_level_t level, bft_offset_t index,

--- a/src/bsfs.h
+++ b/src/bsfs.h
@@ -26,9 +26,6 @@ int bsfs_fsync(bs_file_t file, bool datasync);
 int bsfs_getattr(bs_bsfs_t fs, const char* path, struct stat* st);
 int bsfs_fgetattr(bs_file_t file, struct stat* st);
 
-int bsfs_setattr(bs_bsfs_t fs, const char* path, const struct stat* st);
-int bsfs_fsetattr(bs_file_t file, const struct stat* st);
-
 int bsfs_chmod(bs_bsfs_t fs, const char* path, mode_t mode);
 int bsfs_fchmod(bs_file_t file, mode_t mode);
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -190,6 +190,42 @@ START_TEST(test_unlink_noent) {
 }
 END_TEST
 
+static stego_key_t getattr_key;
+static const char* getattr_level_name = "getattrlvl";
+
+static void getattr_fs_setup(void) {
+  int fd = create_tmp_file(FS_DISK_SIZE);
+  ck_assert_int_eq(bsfs_init(fd, &tmp_fs), 0);
+
+  ck_assert_int_eq(stego_gen_user_keys(&getattr_key, 1), 0);
+  ck_assert_int_eq(
+      keytab_store(tmp_fs->disk, 0, getattr_level_name, &getattr_key), 0);
+
+  void* zero = calloc(1, BFT_SIZE);
+  ck_assert(zero);
+  ck_assert_int_eq(bft_write_table(&getattr_key, tmp_fs->disk, zero), 0);
+  ck_assert_int_eq(fs_write_bitmap(&getattr_key, tmp_fs->disk, zero), 0);
+  free(zero);
+
+  ck_assert_int_eq(bsfs_mknod(tmp_fs, "/getattrlvl/file1", S_IFREG), 0);
+  ck_assert_int_eq(
+      bsfs_mknod(tmp_fs, "/getattrlvl/file2", S_IFREG | S_IRUSR | S_IWUSR), 0);
+}
+
+static void getattr_fs_teardown(void) {
+  bsfs_destroy(tmp_fs);
+}
+
+START_TEST(test_getattr) {
+  struct stat st;
+  ck_assert_int_eq(bsfs_getattr(tmp_fs, "getattrlvl/file1", &st), 0);
+
+  ck_assert_uint_eq(st.st_size, 0);
+  ck_assert_int_eq(st.st_mode, S_IFREG);
+  ck_assert_int_eq(st.st_nlink, 1);
+}
+END_TEST
+
 Suite* bsfs_suite(void) {
   Suite* suite = suite_create("bsfs");
 
@@ -222,6 +258,12 @@ Suite* bsfs_suite(void) {
   tcase_add_test(mknod_unlink_tcase, test_unlink);
   tcase_add_test(mknod_unlink_tcase, test_unlink_noent);
   suite_add_tcase(suite, mknod_unlink_tcase);
+
+  TCase* getattr_tcase = tcase_create("getattr");
+  tcase_add_checked_fixture(getattr_tcase, getattr_fs_setup,
+                            getattr_fs_teardown);
+  tcase_add_test(getattr_tcase, test_getattr);
+  suite_add_tcase(suite, getattr_tcase);
 
   return suite;
 }

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -10,7 +10,7 @@
 #include <unistd.h>
 
 #define FS_DISK_SIZE                                                           \
-  (KEYTAB_SIZE + STEGO_USER_LEVEL_COUNT * (BFT_SIZE + 0x1000))
+  (KEYTAB_SIZE + STEGO_USER_LEVEL_COUNT * (BFT_SIZE + 0x2000))
 
 static int create_tmp_file(size_t size) {
   int fd = syscall(SYS_memfd_create, "test_bsfs.bsf", 0);

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -207,9 +207,8 @@ static void getattr_fs_setup(void) {
   ck_assert_int_eq(fs_write_bitmap(&getattr_key, tmp_fs->disk, zero), 0);
   free(zero);
 
-  ck_assert_int_eq(bsfs_mknod(tmp_fs, "/getattrlvl/file1", S_IFREG), 0);
   ck_assert_int_eq(
-      bsfs_mknod(tmp_fs, "/getattrlvl/file2", S_IFREG | S_IRUSR | S_IWUSR), 0);
+      bsfs_mknod(tmp_fs, "/getattrlvl/file1", S_IFREG | S_IRUSR | S_IWUSR), 0);
 }
 
 static void getattr_fs_teardown(void) {
@@ -221,7 +220,14 @@ START_TEST(test_getattr) {
   ck_assert_int_eq(bsfs_getattr(tmp_fs, "getattrlvl/file1", &st), 0);
 
   ck_assert_uint_eq(st.st_size, 0);
-  ck_assert_int_eq(st.st_mode, S_IFREG);
+  ck_assert_int_eq(st.st_mode, S_IFREG | S_IRUSR | S_IWUSR);
+  ck_assert_int_eq(st.st_nlink, 1);
+}
+END_TEST
+
+START_TEST(test_getattr_noent) {
+  struct stat st;
+  ck_assert_int_eq(bsfs_getattr(tmp_fs, "getattrlvl/asjkdl", &st), -ENOENT);
   ck_assert_int_eq(st.st_nlink, 1);
 }
 END_TEST
@@ -263,6 +269,7 @@ Suite* bsfs_suite(void) {
   tcase_add_checked_fixture(getattr_tcase, getattr_fs_setup,
                             getattr_fs_teardown);
   tcase_add_test(getattr_tcase, test_getattr);
+  tcase_add_test(getattr_tcase, test_getattr_noent);
   suite_add_tcase(suite, getattr_tcase);
 
   return suite;

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -228,7 +228,21 @@ END_TEST
 START_TEST(test_getattr_noent) {
   struct stat st;
   ck_assert_int_eq(bsfs_getattr(tmp_fs, "getattrlvl/asjkdl", &st), -ENOENT);
+}
+END_TEST
+
+START_TEST(test_fgetattr) {
+  bs_file_t file;
+  ck_assert_int_eq(bsfs_open(tmp_fs, "getattrlvl/file1", &file), 0);
+
+  struct stat st;
+  ck_assert_int_eq(bsfs_fgetattr(file, &st), 0);
+
+  ck_assert_uint_eq(st.st_size, 0);
+  ck_assert_int_eq(st.st_mode, S_IFREG | S_IRUSR | S_IWUSR);
   ck_assert_int_eq(st.st_nlink, 1);
+
+  ck_assert_int_eq(bsfs_release(file), 0);
 }
 END_TEST
 
@@ -270,6 +284,7 @@ Suite* bsfs_suite(void) {
                             getattr_fs_teardown);
   tcase_add_test(getattr_tcase, test_getattr);
   tcase_add_test(getattr_tcase, test_getattr_noent);
+  tcase_add_test(getattr_tcase, test_fgetattr);
   suite_add_tcase(suite, getattr_tcase);
 
   return suite;


### PR DESCRIPTION
The `getattr` and `fgetattr` operations are now implemented, while `setattr` and `fsetattr` have been removed &mdash; they are not a part of FUSE's interface and were probably over-extrapolated from the docs.

Basic tests pass, though more should be added in the future when additional operations are available. 