### PR TITLE
Simplify OFT

### DIFF
--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -20,7 +20,7 @@ struct bs_file_impl {
 
 typedef struct bs_oft {
   bs_file_t head;
-  bs_file_t** buckets; // Array of next pointers
+  bs_file_t* buckets;
   size_t bucket_count;
   size_t size;
   pthread_mutex_t lock; // Protects all table operations

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -7,6 +7,7 @@
 #include "disk.h"
 #include <pthread.h>
 #include <stdatomic.h>
+#include <stdbool.h>
 
 struct bs_file_impl {
   struct bs_open_level_impl* level;
@@ -46,6 +47,7 @@ void bs_oft_destroy(bs_oft_t* table);
 
 int bs_oft_get(bs_oft_t* table, bs_open_level_t level, bft_offset_t index,
                bs_file_t* file);
+int bs_oft_has(bs_oft_t* table, bft_offset_t index, bool* out);
 int bs_oft_release(bs_oft_t* table, bs_file_t file);
 
 int bs_level_get(bs_bsfs_t fs, const char* pass, bs_open_level_t* out);

--- a/src/bsfs_priv.h
+++ b/src/bsfs_priv.h
@@ -19,7 +19,6 @@ struct bs_file_impl {
 };
 
 typedef struct bs_oft {
-  bs_file_t head;
   bs_file_t* buckets;
   size_t bucket_count;
   size_t size;

--- a/src/oft.c
+++ b/src/oft.c
@@ -172,12 +172,14 @@ static int oft_insert(bs_oft_t* table, bs_file_t file) {
 
 int bs_oft_init(bs_oft_t* table) {
   memset(table, 0, sizeof(bs_oft_t));
-  int ret = oft_realloc_buckets(table, OFT_INITIAL_BUCKET_COUNT);
-  if (ret < 0) {
-    return ret;
-  }
 
-  ret = -pthread_mutex_init(&table->lock, NULL);
+  table->buckets = calloc(OFT_INITIAL_BUCKET_COUNT, sizeof(bs_file_t));
+  if (!table->buckets) {
+    return -ENOMEM;
+  }
+  table->bucket_count = OFT_INITIAL_BUCKET_COUNT;
+
+  int ret = -pthread_mutex_init(&table->lock, NULL);
   if (ret < 0) {
     free(table->buckets);
   }

--- a/src/oft.c
+++ b/src/oft.c
@@ -194,6 +194,18 @@ unlock:
   return ret;
 }
 
+int bs_oft_has(bs_oft_t* table, bft_offset_t index, bool* out) {
+  int ret = -pthread_mutex_lock(&table->lock);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *out = oft_find(table, index) != NULL;
+
+  pthread_mutex_unlock(&table->lock);
+  return 0;
+}
+
 int bs_oft_release(bs_oft_t* table, bs_file_t file) {
   int new_refcount =
       atomic_fetch_sub_explicit(&file->refcount, 1, memory_order_acq_rel) - 1;

--- a/src/oft.c
+++ b/src/oft.c
@@ -55,29 +55,6 @@ static size_t oft_bucket_of(bft_offset_t index, size_t bucket_count) {
          (bucket_count - 1); // Assumes power-of-2 bucket count.
 }
 
-static bool oft_matches_bucket(bs_file_t file, size_t bucket,
-                               size_t bucket_count) {
-  return file && oft_bucket_of(file->index, bucket_count) == bucket;
-}
-
-static bs_file_t* oft_find_prev(bs_oft_t* table, bft_offset_t index) {
-  size_t bucket = oft_bucket_of(index, table->bucket_count);
-  bs_file_t* prev_link = table->buckets[bucket];
-
-  if (!prev_link) {
-    return NULL;
-  }
-
-  for (; oft_matches_bucket(*prev_link, bucket, table->bucket_count);
-       prev_link = &(*prev_link)->next) {
-    if ((*prev_link)->index == index) {
-      return prev_link;
-    }
-  }
-
-  return NULL;
-}
-
 static bs_file_t oft_find(bs_oft_t* table, bft_offset_t index) {
   bs_file_t iter = table->buckets[oft_bucket_of(index, table->bucket_count)];
   for (; iter; iter = iter->next) {

--- a/src/oft.c
+++ b/src/oft.c
@@ -33,23 +33,6 @@ static void destroy_open_file(bs_file_t file) {
   free(file);
 }
 
-static int oft_realloc_buckets(bs_oft_t* table, size_t bucket_count) {
-  if (!bucket_count || bucket_count & (bucket_count - 1)) {
-    // Not a power of 2
-    return -EINVAL;
-  }
-
-  bs_file_t** new_buckets =
-      (bs_file_t**) calloc(bucket_count, sizeof(bs_file_t*));
-  if (!new_buckets) {
-    return -ENOMEM;
-  }
-  free(table->buckets);
-  table->buckets = new_buckets;
-  table->bucket_count = bucket_count;
-  return 0;
-}
-
 static int alloc_buckets(size_t bucket_count, bs_file_t** out_buckets) {
   if (!bucket_count || bucket_count & (bucket_count - 1)) {
     // Not a power of 2.

--- a/src/oft.c
+++ b/src/oft.c
@@ -57,10 +57,8 @@ static bs_file_t oft_find(bs_oft_t* table, bft_offset_t index) {
   size_t bucket = bucket_of(index, table->bucket_count);
 
   bs_file_t iter = table->buckets[bucket];
-  for (; iter; iter = iter->next) {
-    if (iter->index == index) {
-      break;
-    }
+  while (iter && iter->index != index) {
+    iter = iter->next;
   }
 
   return iter;
@@ -77,10 +75,8 @@ static int oft_remove(bs_oft_t* table, bs_file_t file) {
   size_t bucket = bucket_of(file->index, table->bucket_count);
 
   bs_file_t* iter = &table->buckets[bucket];
-  for (; *iter; iter = &(*iter)->next) {
-    if (*iter == file) {
-      break;
-    }
+  while (*iter && *iter != file) {
+    iter = &(*iter)->next;
   }
 
   if (!*iter) {

--- a/src/oft.c
+++ b/src/oft.c
@@ -97,8 +97,11 @@ static int oft_rehash(bs_oft_t* table, size_t new_bucket_count) {
   }
 
   for (size_t old_bucket = 0; old_bucket < table->bucket_count; old_bucket++) {
-    for (bs_file_t file = table->buckets[old_bucket]; file; file = file->next) {
+    bs_file_t file = table->buckets[old_bucket];
+    while (file) {
+      bs_file_t next = file->next;
       oft_do_insert(new_buckets, new_bucket_count, file);
+      file = next;
     }
   }
 

--- a/src/oft.c
+++ b/src/oft.c
@@ -54,12 +54,15 @@ static size_t bucket_of(bft_offset_t index, size_t bucket_count) {
 }
 
 static bs_file_t oft_find(bs_oft_t* table, bft_offset_t index) {
-  bs_file_t iter = table->buckets[bucket_of(index, table->bucket_count)];
+  size_t bucket = bucket_of(index, table->bucket_count);
+
+  bs_file_t iter = table->buckets[bucket];
   for (; iter; iter = iter->next) {
     if (iter->index == index) {
       break;
     }
   }
+
   return iter;
 }
 

--- a/src/oft.c
+++ b/src/oft.c
@@ -143,7 +143,6 @@ int bs_oft_init(bs_oft_t* table) {
 
 void bs_oft_destroy(bs_oft_t* table) {
   pthread_mutex_destroy(&table->lock);
-  free(table->buckets);
 
   for (size_t bucket = 0; bucket < table->bucket_count; bucket++) {
     bs_file_t file = table->buckets[bucket];
@@ -153,6 +152,8 @@ void bs_oft_destroy(bs_oft_t* table) {
       file = next;
     }
   }
+
+  free(table->buckets);
 }
 
 int bs_oft_get(bs_oft_t* table, bs_open_level_t level, bft_offset_t index,

--- a/src/oft.c
+++ b/src/oft.c
@@ -162,11 +162,13 @@ void bs_oft_destroy(bs_oft_t* table) {
   pthread_mutex_destroy(&table->lock);
   free(table->buckets);
 
-  bs_file_t iter = table->head;
-  while (iter) {
-    bs_file_t next = iter->next;
-    destroy_open_file(iter);
-    iter = next;
+  for (size_t bucket = 0; bucket < table->bucket_count; bucket++) {
+    bs_file_t file = table->buckets[bucket];
+    while (file) {
+      bs_file_t next = file->next;
+      destroy_open_file(file);
+      file = next;
+    }
   }
 }
 

--- a/src/oft.c
+++ b/src/oft.c
@@ -48,13 +48,13 @@ static int alloc_buckets(size_t bucket_count, bs_file_t** out_buckets) {
   return 0;
 }
 
-static size_t oft_bucket_of(bft_offset_t index, size_t bucket_count) {
+static size_t bucket_of(bft_offset_t index, size_t bucket_count) {
   return (size_t) index &
          (bucket_count - 1); // Assumes power-of-2 bucket count.
 }
 
 static bs_file_t oft_find(bs_oft_t* table, bft_offset_t index) {
-  bs_file_t iter = table->buckets[oft_bucket_of(index, table->bucket_count)];
+  bs_file_t iter = table->buckets[bucket_of(index, table->bucket_count)];
   for (; iter; iter = iter->next) {
     if (iter->index == index) {
       break;
@@ -65,13 +65,13 @@ static bs_file_t oft_find(bs_oft_t* table, bft_offset_t index) {
 
 static void oft_do_insert(bs_file_t* buckets, size_t bucket_count,
                           bs_file_t file) {
-  size_t bucket = oft_bucket_of(file->index, bucket_count);
+  size_t bucket = bucket_of(file->index, bucket_count);
   file->next = buckets[bucket];
   buckets[bucket] = file;
 }
 
 static int oft_remove(bs_oft_t* table, bs_file_t file) {
-  size_t bucket = oft_bucket_of(file->index, table->bucket_count);
+  size_t bucket = bucket_of(file->index, table->bucket_count);
 
   bs_file_t* iter = &table->buckets[bucket];
   for (; *iter; iter = &(*iter)->next) {

--- a/tests/test_oft.c
+++ b/tests/test_oft.c
@@ -203,7 +203,6 @@ START_TEST(test_oft_remove_empty) {
   ck_assert_int_eq(bs_oft_get(&table, NULL, 123, &file), 0);
   ck_assert_int_eq(bs_oft_release(&table, file), 0);
 
-  ck_assert_ptr_eq(table.head, NULL);
   for (size_t i = 0; i < table.bucket_count; i++) {
     ck_assert_ptr_eq(table.buckets[i], NULL);
   }

--- a/tests/test_oft.c
+++ b/tests/test_oft.c
@@ -195,6 +195,67 @@ START_TEST(test_oft_insert_after_rehash) {
 }
 END_TEST
 
+START_TEST(test_oft_has) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file), 0);
+
+  bool has;
+  ck_assert_int_eq(bs_oft_has(&table, 0, &has), 0);
+  ck_assert(has);
+
+  bs_oft_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_oft_has_not) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file), 0);
+
+  bool has;
+  ck_assert_int_eq(bs_oft_has(&table, 123, &has), 0);
+  ck_assert(!has);
+
+  bs_oft_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_oft_has_same_bucket) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file), 0);
+  ck_assert_int_eq(bs_oft_get(&table, NULL, table.bucket_count, &file), 0);
+
+  bool has;
+  ck_assert_int_eq(bs_oft_has(&table, 0, &has), 0);
+  ck_assert(has);
+
+  bs_oft_destroy(&table);
+}
+END_TEST
+
+START_TEST(test_oft_has_not_same_bucket) {
+  bs_oft_t table;
+  ck_assert_int_eq(bs_oft_init(&table), 0);
+
+  bs_file_t file;
+  ck_assert_int_eq(bs_oft_get(&table, NULL, 0, &file), 0);
+
+  bool has;
+  ck_assert_int_eq(bs_oft_has(&table, table.bucket_count, &has), 0);
+  ck_assert(!has);
+
+  bs_oft_destroy(&table);
+}
+END_TEST
+
 START_TEST(test_oft_remove_empty) {
   bs_oft_t table;
   ck_assert_int_eq(bs_oft_init(&table), 0);
@@ -361,6 +422,13 @@ Suite* oft_suite(void) {
   tcase_add_test(rehash_tcase, test_oft_rehash);
   tcase_add_test(rehash_tcase, test_oft_insert_after_rehash);
   suite_add_tcase(suite, rehash_tcase);
+
+  TCase* has_tcase = tcase_create("has");
+  tcase_add_test(has_tcase, test_oft_has);
+  tcase_add_test(has_tcase, test_oft_has_not);
+  tcase_add_test(has_tcase, test_oft_has_same_bucket);
+  tcase_add_test(has_tcase, test_oft_has_not_same_bucket);
+  suite_add_tcase(suite, has_tcase);
 
   TCase* remove_tcase = tcase_create("remove");
   tcase_add_test(remove_tcase, test_oft_remove_empty);


### PR DESCRIPTION
The OFT now no longer chains all buckets into one long (singly-)linked list, but rather holds a separate linked list for each bucket. This makes the code significantly simpler and less confusing; in particular, the bucket array no longer needs triple pointers and there aren't nearly as many edge cases to handle as there were in the old implementation.

This change also introduces `bs_oft_has`, which can be used to check whether a particular file is present in the OFT without taking a reference to it. The intended use case of this function is in operations that must fail when a file is open, such as `unlink`.