### PR TITLE
Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM nmraz/bsfs-build-env:latest
 COPY . /bsfs
 WORKDIR /bsfs
 
-CMD [ "/bin/bash", "-c", "mkdir build && cd build && CC=clang cmake -G Ninja .. && cmake --build . && ctest -V" ]
+CMD [ "/bin/bash", "-c", "mkdir build && cd build && CC=clang cmake -DCMAKE_BUILD_TYPE=Release -G Ninja .. && cmake --build . && ctest -V" ]

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -386,11 +386,12 @@ int bsfs_mknod(bs_bsfs_t fs, const char* path, mode_t mode) {
 
   ret = write_cluster(level, cluster_data, initial_cluster);
   if (ret < 0) {
-    fs_dealloc_cluster(level->bitmap, bitmap_bits, initial_cluster);
+    FUSE_CAP_WRITEBACK_CACH
+    fs_dealloc_cFUSE_CAP_WRITEBACK_CACHitmap_bits, initial_cluster);
   }
 
-  bft_entry_t ent;
-  ret = bft_entry_init(&ent, name, 0, mode, initial_cluster, 0, 0);
+  bft_entry_t enFUSE_CAP_WRITEBACK_CACH
+  ret = bft_entrFUSE_CAP_WRITEBACK_CACHode, initial_cluster, 0, 0);
   if (ret < 0) {
     fs_dealloc_cluster(level->bitmap, bitmap_bits, initial_cluster);
     goto cleanup_after_metadata;
@@ -470,9 +471,10 @@ int bsfs_open(bs_bsfs_t fs, const char* path, bs_file_t* file) {
   if (ret < 0) {
     return ret;
   }
-  pthread_rwlock_unlock(&level->metadata_lock);
 
-  return bs_oft_get(&level->open_files, level, index, file);
+  ret = bs_oft_get(&level->open_files, level, index, file);
+  pthread_rwlock_unlock(&level->metadata_lock);
+  return ret;
 }
 
 int bsfs_release(bs_file_t file) {

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -412,8 +412,16 @@ cleanup:
 }
 
 static int do_unlink(bs_open_level_t level, bft_offset_t index) {
+  bool is_open;
+  int ret = bs_oft_has(&level->open_files, index, &is_open);
+  if (ret < 0) {
+    return ret;
+  }
+  if (is_open) {
+    return -EBUSY;
+  }
   bft_entry_t ent;
-  int ret = bft_read_table_entry(level->bft, &ent, index);
+  ret = bft_read_table_entry(level->bft, &ent, index);
   if (ret < 0) {
     return ret;
   }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -386,12 +386,11 @@ int bsfs_mknod(bs_bsfs_t fs, const char* path, mode_t mode) {
 
   ret = write_cluster(level, cluster_data, initial_cluster);
   if (ret < 0) {
-    FUSE_CAP_WRITEBACK_CACH
-    fs_dealloc_cFUSE_CAP_WRITEBACK_CACHitmap_bits, initial_cluster);
+    fs_dealloc_cluster(level->bitmap, bitmap_bits, initial_cluster);
   }
 
-  bft_entry_t enFUSE_CAP_WRITEBACK_CACH
-  ret = bft_entrFUSE_CAP_WRITEBACK_CACHode, initial_cluster, 0, 0);
+  bft_entry_t ent;
+  ret = bft_entry_init(&ent, name, 0, mode, initial_cluster, 0, 0);
   if (ret < 0) {
     fs_dealloc_cluster(level->bitmap, bitmap_bits, initial_cluster);
     goto cleanup_after_metadata;

--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -25,6 +25,7 @@ static void set_file(struct fuse_file_info* fi, bs_file_t file) {
 void* bsfs_fuse_init(struct fuse_conn_info* conn, struct fuse_config* cfg) {
   conn->time_gran = 1000000000; // 1 second
   conn->want |= FUSE_CAP_WRITEBACK_CACHE;
+  conn->want &= !FUSE_CAP_ATOMIC_O_TRUNC;
 
   cfg->set_uid = true;
   cfg->uid = getuid();

--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -25,7 +25,7 @@ static void set_file(struct fuse_file_info* fi, bs_file_t file) {
 void* bsfs_fuse_init(struct fuse_conn_info* conn, struct fuse_config* cfg) {
   conn->time_gran = 1000000000; // 1 second
   conn->want |= FUSE_CAP_WRITEBACK_CACHE;
-  conn->want &= !FUSE_CAP_ATOMIC_O_TRUNC;
+  conn->want &= ~FUSE_CAP_ATOMIC_O_TRUNC;
 
   cfg->set_uid = true;
   cfg->uid = getuid();

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -206,7 +206,8 @@ END_TEST
 START_TEST(test_mknod_file_exists) {
   char path[256];
   strcpy(path, mknod_level_name);
-  strcat(path, "/bla") ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), 0);
+  strcat(path, "/bla");
+  ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), 0);
   ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), -EEXIST);
 }
 END_TEST

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -236,6 +236,18 @@ START_TEST(test_unlink) {
 }
 END_TEST
 
+START_TEST(test_unlink_file_open) {
+  char path[256];
+  strcpy(path, mknod_level_name);
+  strcat(path, "/bla");
+  ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), 0);
+  bs_file_t file;
+  ck_assert_int_eq(bsfs_open(tmp_fs, path, &file), 0);
+
+  ck_assert_int_eq(bsfs_unlink(tmp_fs, path), -EBUSY);
+}
+END_TEST
+
 START_TEST(test_unlink_noent) {
   char path[256];
   strcpy(path, mknod_level_name);
@@ -1224,6 +1236,7 @@ Suite* bsfs_suite(void) {
   tcase_add_test(mknod_unlink_tcase, test_mknod_not_reg);
   tcase_add_test(mknod_unlink_tcase, test_mknod_no_such_level);
   tcase_add_test(mknod_unlink_tcase, test_unlink);
+  tcase_add_test(mknod_unlink_tcase, test_unlink_file_open);
   tcase_add_test(mknod_unlink_tcase, test_unlink_noent);
   suite_add_tcase(suite, mknod_unlink_tcase);
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -206,7 +206,7 @@ END_TEST
 START_TEST(test_mknod_file_exists) {
   char path[256];
   strcpy(path, mknod_level_name);
-  ck_assert_int_eq(bsfs_mknod(tmp_fs, strcat(path, "/bla"), S_IFREG), 0);
+  strcat(path, "/bla") ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), 0);
   ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), -EEXIST);
 }
 END_TEST

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -203,6 +203,14 @@ START_TEST(test_mknod) {
 }
 END_TEST
 
+START_TEST(test_mknod_file_exists) {
+  char path[256];
+  strcpy(path, mknod_level_name);
+  ck_assert_int_eq(bsfs_mknod(tmp_fs, strcat(path, "/bla"), S_IFREG), 0);
+  ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), -EEXIST);
+}
+END_TEST
+
 START_TEST(test_mknod_not_reg) {
   char path[256];
   strcpy(path, mknod_level_name);
@@ -1211,6 +1219,7 @@ Suite* bsfs_suite(void) {
   tcase_add_checked_fixture(mknod_unlink_tcase, mknod_fs_setup,
                             mknod_fs_teardown);
   tcase_add_test(mknod_unlink_tcase, test_mknod);
+  tcase_add_test(mknod_unlink_tcase, test_mknod_file_exists);
   tcase_add_test(mknod_unlink_tcase, test_mknod_not_reg);
   tcase_add_test(mknod_unlink_tcase, test_mknod_no_such_level);
   tcase_add_test(mknod_unlink_tcase, test_unlink);

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -232,7 +232,7 @@ START_TEST(test_unlink) {
   ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), 0);
   ck_assert_int_eq(bsfs_unlink(tmp_fs, path), 0);
   bs_file_t file;
-  ck_assert_int_eq(bsfs_open(tmp_fs, path, &file), -2);
+  ck_assert_int_eq(bsfs_open(tmp_fs, path, &file), -ENOENT);
 }
 END_TEST
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -231,7 +231,8 @@ START_TEST(test_unlink) {
   strcat(path, "/bla");
   ck_assert_int_eq(bsfs_mknod(tmp_fs, path, S_IFREG), 0);
   ck_assert_int_eq(bsfs_unlink(tmp_fs, path), 0);
-  // TODO: Make sure file doesn't exist!
+  bs_file_t file;
+  ck_assert_int_eq(bsfs_open(tmp_fs, path, &file), -2);
 }
 END_TEST
 

--- a/tests/test_keytab.c
+++ b/tests/test_keytab.c
@@ -106,7 +106,7 @@ START_TEST(test_keytab_store_lookup_roundtrip) {
   ck_assert_int_eq(keytab_store(disk, 0, pass1, &key1), 0);
   ck_assert_int_eq(keytab_store(disk, 1, pass2, &key2), 0);
 
-  stego_key_t recovered_key = { { 0 } };
+  stego_key_t recovered_key = { { 0 }, { { 0 } }, { { 0 } } };
 
   ck_assert_int_eq(keytab_lookup(disk, pass1, &recovered_key), 0);
   ck_assert(stego_key_eq(&recovered_key, &key1));


### PR DESCRIPTION
Fix the following issues:

- Fix race condition in `open` - metadata should be locked when OFT is updated
- Support `O_TRUNC` in `open` (or turn off `FUSE_CAP_ATOMIC_O_TRUNC`)
- Test `mknod` when file exists
- Ensure file is deleted `unlink` tests
- `unlink` should fail if file is open