### PR TITLE
Implement truncate and fallocate

### DIFF
--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -700,6 +700,7 @@ static int dealloc_clusters(bs_open_level_t level,
 }
 
 size_t get_required_cluster_count(off_t file_size) {
+  // Divide by `CLUSTER_DATA_SIZE`, but round up.
   return (file_size + CLUSTER_DATA_SIZE - 1) / CLUSTER_DATA_SIZE;
 }
 

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -540,7 +540,9 @@ static int find_cluster(bs_open_level_t level, cluster_offset_t cluster_idx,
   }
 
   *found = cluster_idx;
-  *local_off = off;
+  if (local_off) {
+    *local_off = off;
+  }
   return 0;
 }
 
@@ -818,9 +820,7 @@ static int find_eof_cluster(bs_open_level_t level,
     return 0;
   }
   // Find the cluster containing the last byte.
-  off_t dummy;
-  return find_cluster(level, initial_cluster, file_size - 1, eof_cluster,
-                      &dummy);
+  return find_cluster(level, initial_cluster, file_size - 1, eof_cluster, NULL);
 }
 
 ssize_t bsfs_write(bs_file_t file, const void* buf, size_t size, off_t off) {
@@ -1053,9 +1053,7 @@ int bsfs_ftruncate(bs_file_t file, off_t new_size) {
              get_required_cluster_count(size)) {
     // Shrink
     cluster_offset_t new_eof;
-    off_t dummy;
-    ret =
-        find_cluster(file->level, initial_cluster, new_size, &new_eof, &dummy);
+    ret = find_cluster(file->level, initial_cluster, new_size, &new_eof, NULL);
     if (ret < 0) {
       goto unlock;
     }

--- a/src/bsfs.c
+++ b/src/bsfs.c
@@ -1048,7 +1048,7 @@ int bsfs_ftruncate(bs_file_t file, off_t new_size) {
     }
 
     ret = bs_do_write_extend(file->level, curr_eof, get_local_eof_off(size),
-                             NULL, 0, new_size);
+                             NULL, 0, new_size - size);
   } else if (get_required_cluster_count(new_size) <
              get_required_cluster_count(size)) {
     // Shrink

--- a/src/bsfs.h
+++ b/src/bsfs.h
@@ -33,6 +33,8 @@ int bsfs_fchmod(bs_file_t file, mode_t mode);
 int bsfs_truncate(bs_bsfs_t fs, const char* path, off_t size);
 int bsfs_ftruncate(bs_file_t file, off_t size);
 
+int bsfs_fallocate(bs_file_t file, off_t size);
+
 int bsfs_utimens(bs_bsfs_t fs, const char* path,
                  const struct timespec times[2]);
 int bsfs_futimens(bs_file_t file, const struct timespec times[2]);

--- a/src/bsfs.h
+++ b/src/bsfs.h
@@ -33,7 +33,7 @@ int bsfs_fchmod(bs_file_t file, mode_t mode);
 int bsfs_truncate(bs_bsfs_t fs, const char* path, off_t size);
 int bsfs_ftruncate(bs_file_t file, off_t size);
 
-int bsfs_fallocate(bs_file_t file, off_t size);
+int bsfs_fallocate(bs_file_t file, off_t off, off_t len);
 
 int bsfs_utimens(bs_bsfs_t fs, const char* path,
                  const struct timespec times[2]);

--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -1,6 +1,7 @@
 #include "fuse_ops.h"
 
 #include "bsfs.h"
+#include <errno.h>
 #include <stdbool.h>
 #include <unistd.h>
 
@@ -117,6 +118,15 @@ int bsfs_fuse_utimens(const char* path, const struct timespec times[2],
   bs_file_t file = try_get_file(fi);
   return file ? bsfs_futimens(file, times)
               : bsfs_utimens(get_fs(), path, times);
+}
+
+int bsfs_fuse_fallocate(const char* path, int mode, off_t off, off_t len,
+                        struct fuse_file_info* fi) {
+  (void) path;
+  if (mode) {
+    return -ENOTSUP;
+  }
+  return bsfs_fallocate(get_file(fi), off, len);
 }
 
 int bsfs_fuse_rename(const char* oldpath, const char* newpath,

--- a/src/fuse_ops.h
+++ b/src/fuse_ops.h
@@ -29,6 +29,9 @@ int bsfs_fuse_truncate(const char* path, off_t size, struct fuse_file_info* fi);
 int bsfs_fuse_utimens(const char* path, const struct timespec times[2],
                       struct fuse_file_info* fi);
 
+int bsfs_fuse_fallocate(const char* path, int mode, off_t off, off_t len,
+                        struct fuse_file_info* fi);
+
 int bsfs_fuse_rename(const char* oldpath, const char* newpath,
                      unsigned int flags);
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -1234,21 +1234,21 @@ static void truncate_fs_teardown(void) {
 }
 
 START_TEST(test_ftruncate_extend) {
-  ck_assert_int_eq(bsfs_ftruncate(truncate_file, 30), 0);
+  ck_assert_int_eq(bsfs_ftruncate(truncate_file, strlen(truncate_str) + 10), 0);
 
   uint8_t buf[10];
   uint8_t expected[sizeof(buf)] = { 0 };
-  ck_assert_int_eq(bsfs_read(truncate_file, buf, 10, 20), 10);
+  ck_assert_int_eq(bsfs_read(truncate_file, buf, sizeof(buf), strlen(truncate_str)), sizeof(buf));
   ck_assert_int_eq(memcmp(buf, expected, sizeof(buf)), 0);
 }
 END_TEST
 
 START_TEST(test_ftruncate_same_size) {
-  ck_assert_int_eq(bsfs_ftruncate(truncate_file, 20), 0);
+  ck_assert_int_eq(bsfs_ftruncate(truncate_file, strlen(truncate_str)), 0);
 
   struct stat st;
   ck_assert_int_eq(bsfs_fgetattr(truncate_file, &st), 0);
-  ck_assert_int_eq(st.st_size, 20);
+  ck_assert_int_eq(st.st_size, strlen(truncate_str));
 }
 END_TEST
 

--- a/tests/test_bsfs.c
+++ b/tests/test_bsfs.c
@@ -6,7 +6,6 @@
 #include "stego.h"
 #include <errno.h>
 #include <linux/stat.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -1286,7 +1285,6 @@ START_TEST(test_ftruncate_shrink_dealloc) {
   uint8_t buf[4] = { 0 };
   ck_assert_int_eq(bsfs_read(truncate_file, buf, 3, 0), 3);
   const char* expected = "sal";
-  printf("%s", buf);
   ck_assert_int_eq(memcmp(buf, expected, 3), 0);
   ck_assert_int_eq(bsfs_fgetattr(truncate_file, &st), 0);
   ck_assert_int_eq(st.st_size, 3);


### PR DESCRIPTION
In addition to implementing `ftruncate` and `fallocate`, this change also includes a few fixes for bugs that were found in `read` and `write`.