### PR TITLE
Avoid expensive key derivation on every stego operation

### DIFF
--- a/src/enc.c
+++ b/src/enc.c
@@ -7,8 +7,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#define NROUNDS 10000
-
 static_assert(ENC_BLOCK_SIZE == AES_BLOCK_SIZE,
               "Incorrect block size constant");
 

--- a/src/enc.c
+++ b/src/enc.c
@@ -1,5 +1,6 @@
 #include "enc.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <openssl/aes.h>
 #include <openssl/evp.h>
@@ -8,29 +9,11 @@
 
 #define NROUNDS 10000
 
-static int gen_key(const EVP_CIPHER* cipher, const void* password,
-                   size_t password_size, const void* salt, size_t salt_size,
-                   void* key, void* iv) {
-  uint8_t key_iv[EVP_MAX_KEY_LENGTH + EVP_MAX_IV_LENGTH];
-
-  int keylen = EVP_CIPHER_key_length(cipher);
-  int ivlen = EVP_CIPHER_iv_length(cipher);
-
-  int ret = enc_key_from_bytes(password, password_size, salt, salt_size,
-                               NROUNDS, keylen + ivlen, key_iv);
-  if (ret < 0) {
-    return ret;
-  }
-
-  memcpy(key, key_iv, keylen);
-  memcpy(iv, key_iv + keylen, ivlen);
-
-  return 0;
-}
+static_assert(ENC_BLOCK_SIZE == AES_BLOCK_SIZE,
+              "Incorrect block size constant");
 
 static int
-init_cipher_ctx(const EVP_CIPHER* cipher, const void* password,
-                size_t password_size, const void* salt, size_t salt_size,
+init_cipher_ctx(const EVP_CIPHER* cipher, const void* key, const void* iv,
                 int (*init_func)(EVP_CIPHER_CTX*, const EVP_CIPHER*, ENGINE*,
                                  const uint8_t*, const uint8_t*),
                 EVP_CIPHER_CTX** ctx) {
@@ -39,26 +22,14 @@ init_cipher_ctx(const EVP_CIPHER* cipher, const void* password,
     return -ENOMEM;
   }
 
-  uint8_t key[EVP_MAX_KEY_LENGTH];
-  uint8_t iv[EVP_MAX_IV_LENGTH];
-
-  int ret = gen_key(cipher, password, password_size, salt, salt_size, key, iv);
-  if (ret < 0) {
-    goto fail;
-  }
-
   if (!init_func(tmp_ctx, cipher, NULL, key, iv)) {
-    ret = -EIO;
-    goto fail;
+    EVP_CIPHER_CTX_free(tmp_ctx);
+    return -EIO;
   }
   EVP_CIPHER_CTX_set_padding(tmp_ctx, 0);
 
   *ctx = tmp_ctx;
   return 0;
-
-fail:
-  EVP_CIPHER_CTX_free(tmp_ctx);
-  return ret;
 }
 
 int enc_key_from_bytes(const void* password, size_t password_size,
@@ -71,15 +42,15 @@ int enc_key_from_bytes(const void* password, size_t password_size,
              : -EIO;
 }
 
-int aes_encrypt(const void* password, size_t password_size, const void* salt,
-                size_t salt_size, const void* plain, void* enc, size_t size) {
-  if (size % AES_BLOCK_SIZE != 0) {
+int aes_encrypt(const void* key, const void* iv, const void* plain, void* enc,
+                size_t size) {
+  if (size % ENC_BLOCK_SIZE != 0) {
     return -EINVAL;
   }
 
   EVP_CIPHER_CTX* e_ctx;
-  int ret = init_cipher_ctx(EVP_aes_128_cbc(), password, password_size, salt,
-                            salt_size, EVP_EncryptInit_ex, &e_ctx);
+  int ret =
+      init_cipher_ctx(EVP_aes_128_cbc(), key, iv, EVP_EncryptInit_ex, &e_ctx);
   if (ret < 0) {
     return ret;
   }
@@ -108,15 +79,15 @@ cleanup:
   return ret;
 }
 
-int aes_decrypt(const void* password, size_t password_size, const void* salt,
-                size_t salt_size, const void* enc, void* plain, size_t size) {
-  if (size % AES_BLOCK_SIZE != 0) {
+int aes_decrypt(const void* key, const void* iv, const void* enc, void* plain,
+                size_t size) {
+  if (size % ENC_BLOCK_SIZE != 0) {
     return -EINVAL;
   }
 
   EVP_CIPHER_CTX* d_ctx;
-  int ret = init_cipher_ctx(EVP_aes_128_cbc(), password, password_size, salt,
-                            salt_size, EVP_DecryptInit_ex, &d_ctx);
+  int ret =
+      init_cipher_ctx(EVP_aes_128_cbc(), key, iv, EVP_DecryptInit_ex, &d_ctx);
   if (ret < 0) {
     return ret;
   }
@@ -146,12 +117,11 @@ cleanup:
   return ret;
 }
 
-int aes_encrypt_auth(const void* password, size_t password_size,
-                     const void* salt, size_t salt_size, const void* plain,
+int aes_encrypt_auth(const void* key, const void* iv, const void* plain,
                      void* enc, size_t size, void* tag, size_t tag_size) {
   EVP_CIPHER_CTX* e_ctx;
-  int ret = init_cipher_ctx(EVP_aes_128_gcm(), password, password_size, salt,
-                            salt_size, EVP_EncryptInit_ex, &e_ctx);
+  int ret =
+      init_cipher_ctx(EVP_aes_128_gcm(), key, iv, EVP_EncryptInit_ex, &e_ctx);
   if (ret < 0) {
     return ret;
   }
@@ -185,13 +155,12 @@ cleanup:
   return ret;
 }
 
-int aes_decrypt_auth(const void* password, size_t password_size,
-                     const void* salt, size_t salt_size, const void* enc,
+int aes_decrypt_auth(const void* key, const void* iv, const void* enc,
                      void* plain, size_t size, const void* tag,
                      size_t tag_size) {
   EVP_CIPHER_CTX* d_ctx;
-  int ret = init_cipher_ctx(EVP_aes_128_gcm(), password, password_size, salt,
-                            salt_size, EVP_DecryptInit_ex, &d_ctx);
+  int ret =
+      init_cipher_ctx(EVP_aes_128_gcm(), key, iv, EVP_DecryptInit_ex, &d_ctx);
   if (ret < 0) {
     return ret;
   }

--- a/src/enc.h
+++ b/src/enc.h
@@ -3,6 +3,10 @@
 
 #include <stddef.h>
 
+int enc_key_from_bytes(const void* password, size_t password_size,
+                       const void* salt, size_t salt_size, int iter,
+                       size_t key_size, void* key);
+
 int aes_encrypt(const void* password, size_t password_size, const void* salt,
                 size_t salt_size, const void* plain, void* enc, size_t size);
 int aes_decrypt(const void* password, size_t password_size, const void* salt,

--- a/src/enc.h
+++ b/src/enc.h
@@ -3,20 +3,25 @@
 
 #include <stddef.h>
 
+#define ENC_KEY_SIZE 16
+#define ENC_IV_SIZE 16
+#define ENC_BLOCK_SIZE 16
+
+#define ENC_AUTH_KEY_SIZE 16
+#define ENC_AUTH_IV_SIZE 12
+
 int enc_key_from_bytes(const void* password, size_t password_size,
                        const void* salt, size_t salt_size, int iter,
                        size_t key_size, void* key);
 
-int aes_encrypt(const void* password, size_t password_size, const void* salt,
-                size_t salt_size, const void* plain, void* enc, size_t size);
-int aes_decrypt(const void* password, size_t password_size, const void* salt,
-                size_t salt_size, const void* enc, void* plain, size_t size);
+int aes_encrypt(const void* key, const void* iv, const void* plain, void* enc,
+                size_t size);
+int aes_decrypt(const void* key, const void* iv, const void* enc, void* plain,
+                size_t size);
 
-int aes_encrypt_auth(const void* password, size_t password_size,
-                     const void* salt, size_t salt_size, const void* plain,
+int aes_encrypt_auth(const void* key, const void* iv, const void* plain,
                      void* enc, size_t size, void* tag, size_t tag_size);
-int aes_decrypt_auth(const void* password, size_t password_size,
-                     const void* salt, size_t salt_size, const void* enc,
+int aes_decrypt_auth(const void* key, const void* iv, const void* enc,
                      void* plain, size_t size, const void* tag,
                      size_t tag_size);
 

--- a/src/keytab.c
+++ b/src/keytab.c
@@ -8,6 +8,14 @@
 #include <string.h>
 
 #define KEYTAB_KEY_ENTRY_SIZE (KEYTAB_ENTRY_SIZE - KEYTAB_TAG_SIZE)
+#define KEYTAB_KEY_IV_SIZE (ENC_AUTH_KEY_SIZE + ENC_AUTH_IV_SIZE)
+#define KEYTAB_PBKDF_ITER 10000
+
+static int gen_key_iv(const void* password, size_t password_len,
+                      const void* salt, void* buf) {
+  return enc_key_from_bytes(password, password_len, salt, KEYTAB_SALT_SIZE,
+                            KEYTAB_PBKDF_ITER, KEYTAB_KEY_IV_SIZE, buf);
+}
 
 int keytab_lookup(bs_disk_t disk, const char* password, stego_key_t* key) {
   // Get the key table
@@ -27,30 +35,36 @@ int keytab_lookup(bs_disk_t disk, const char* password, stego_key_t* key) {
   const uint8_t* keytab_data = keytab + KEYTAB_SALT_SIZE;
 
   size_t password_len = strlen(password);
-  uint8_t key_buf[KEYTAB_KEY_ENTRY_SIZE]; // Will hold serialized key
+  uint8_t ent[KEYTAB_KEY_ENTRY_SIZE]; // Will hold serialized key
 
   // Search for key in table
   for (size_t i = 0; i < STEGO_USER_LEVEL_COUNT; i++) {
     const uint8_t* encrypted_ent = keytab_data + i * KEYTAB_ENTRY_SIZE;
 
-    int decrypt_status = aes_decrypt_auth(
-        password, password_len, salt, KEYTAB_SALT_SIZE, encrypted_ent, key_buf,
-        KEYTAB_KEY_ENTRY_SIZE, encrypted_ent + KEYTAB_KEY_ENTRY_SIZE,
-        KEYTAB_TAG_SIZE);
+    uint8_t key_iv[KEYTAB_KEY_IV_SIZE];
+    int ret = gen_key_iv(password, password_len, salt, key_iv);
+    if (ret < 0) {
+      return ret;
+    }
 
-    if (decrypt_status == 0) {
+    ret = aes_decrypt_auth(key_iv, key_iv + ENC_AUTH_KEY_SIZE, encrypted_ent,
+                           ent, KEYTAB_KEY_ENTRY_SIZE,
+                           encrypted_ent + KEYTAB_KEY_ENTRY_SIZE,
+                           KEYTAB_TAG_SIZE);
+
+    if (ret == 0) {
       // Deserialize the key
-      memcpy(key->aes_key, key_buf, sizeof(key->aes_key));
-      memcpy(key->read_keys, key_buf + sizeof(key->aes_key),
+      memcpy(key->aes_key, ent, sizeof(key->aes_key));
+      memcpy(key->read_keys, ent + sizeof(key->aes_key),
              sizeof(key->read_keys));
       memcpy(key->write_keys,
-             key_buf + sizeof(key->aes_key) + sizeof(key->read_keys),
+             ent + sizeof(key->aes_key) + sizeof(key->read_keys),
              sizeof(key->write_keys));
     }
 
-    if (decrypt_status != -EBADMSG) {
+    if (ret != -EBADMSG) {
       // Either the key was found or there was an unknown error
-      return decrypt_status;
+      return ret;
     }
   }
 
@@ -73,25 +87,29 @@ int keytab_store(bs_disk_t disk, off_t index, const char* password,
   const void* salt = keytab;
   uint8_t* keytab_data = (uint8_t*) keytab + KEYTAB_SALT_SIZE;
 
-  uint8_t key_buf[KEYTAB_KEY_ENTRY_SIZE]; // Will hold serialized key
+  uint8_t ent[KEYTAB_KEY_ENTRY_SIZE]; // Will hold serialized key
 
   // Serialize the key
-  memcpy(key_buf, key->aes_key, sizeof(key->aes_key));
-  memcpy(key_buf + sizeof(key->aes_key), key->read_keys,
-         sizeof(key->read_keys));
-  memcpy(key_buf + sizeof(key->aes_key) + sizeof(key->read_keys),
-         key->write_keys, sizeof(key->write_keys));
+  memcpy(ent, key->aes_key, sizeof(key->aes_key));
+  memcpy(ent + sizeof(key->aes_key), key->read_keys, sizeof(key->read_keys));
+  memcpy(ent + sizeof(key->aes_key) + sizeof(key->read_keys), key->write_keys,
+         sizeof(key->write_keys));
+
+  uint8_t key_iv[KEYTAB_KEY_IV_SIZE];
+  int ret = gen_key_iv(password, strlen(password), salt, key_iv);
 
   // Store the key in the key table
-  uint8_t ent[KEYTAB_ENTRY_SIZE];
-  int ret = aes_encrypt_auth(password, strlen(password), salt, KEYTAB_SALT_SIZE,
-                             key_buf, ent, KEYTAB_KEY_ENTRY_SIZE,
-                             ent + KEYTAB_KEY_ENTRY_SIZE, KEYTAB_TAG_SIZE);
+  uint8_t encrypted_ent[KEYTAB_ENTRY_SIZE];
+  ret =
+      aes_encrypt_auth(key_iv, key_iv + ENC_AUTH_KEY_SIZE, ent, encrypted_ent,
+                       KEYTAB_KEY_ENTRY_SIZE,
+                       encrypted_ent + KEYTAB_KEY_ENTRY_SIZE, KEYTAB_TAG_SIZE);
   if (ret < 0) {
     goto cleanup;
   }
 
-  memcpy(keytab_data + index * KEYTAB_ENTRY_SIZE, ent, KEYTAB_ENTRY_SIZE);
+  memcpy(keytab_data + index * KEYTAB_ENTRY_SIZE, encrypted_ent,
+         KEYTAB_ENTRY_SIZE);
 
 cleanup:
   disk_unlock_write(disk);

--- a/src/keytab.h
+++ b/src/keytab.h
@@ -2,12 +2,13 @@
 #define BS_KEYTAB_H
 
 #include "disk.h"
+#include "enc.h"
 #include "stego.h"
 #include <sys/types.h>
 
 #define KEYTAB_TAG_SIZE 16
 #define KEYTAB_ENTRY_SIZE                                                      \
-  (STEGO_AES_KEY_SIZE + STEGO_LEVELS_PER_PASSWORD * STEGO_KEY_SIZE * 2 +       \
+  (ENC_KEY_SIZE + STEGO_LEVELS_PER_PASSWORD * STEGO_KEY_SIZE * 2 +             \
    KEYTAB_TAG_SIZE)
 #define KEYTAB_SALT_SIZE 16
 

--- a/src/stego.c
+++ b/src/stego.c
@@ -53,7 +53,7 @@ int stego_gen_user_keys(stego_key_t* keys, size_t count) {
   matrix_transpose(write_keys, write_keys, STEGO_COVER_FILE_COUNT);
 
   for (size_t i = 0; i < count; i++) {
-    if (!RAND_bytes(keys[i].aes_key, STEGO_AES_KEY_SIZE)) {
+    if (!RAND_bytes(keys[i].aes_key, ENC_KEY_SIZE)) {
       return -EIO;
     }
     memcpy(keys[i].read_keys, read_keys + i * STEGO_USER_KEY_SIZE,
@@ -146,7 +146,7 @@ static void write_merged_cover_file_delta(const stego_key_t* key, void* disk,
 static bool check_parameters(size_t user_level_size, off_t off,
                              size_t buf_size) {
   return (size_t) off < user_level_size && buf_size < user_level_size - off &&
-         buf_size % 16 == 0 && off % 16 == 0;
+         buf_size % ENC_BLOCK_SIZE == 0 && off % ENC_BLOCK_SIZE == 0;
 }
 
 int stego_read_level(const stego_key_t* key, bs_disk_t disk, void* buf,
@@ -176,7 +176,8 @@ int stego_read_level(const stego_key_t* key, bs_disk_t disk, void* buf,
 
   disk_unlock_read(disk);
 
-  ret = aes_decrypt(key->aes_key, STEGO_AES_KEY_SIZE, NULL, 0, data, buf, size);
+  uint8_t iv[ENC_IV_SIZE] = { 0 }; // TODO: generate IV from offset.
+  ret = aes_decrypt(key->aes_key, iv, data, buf, size);
 
 cleanup_data:
   free(data);
@@ -199,8 +200,8 @@ int stego_write_level(const stego_key_t* key, bs_disk_t disk, const void* buf,
   }
   void* disk_data;
 
-  int ret = aes_encrypt(key->aes_key, STEGO_AES_KEY_SIZE, NULL, 0, buf,
-                        encrypted, size);
+  uint8_t iv[ENC_IV_SIZE] = { 0 }; // TODO: generate IV from offset.
+  int ret = aes_encrypt(key->aes_key, iv, buf, encrypted, size);
   if (ret < 0) {
     goto cleanup;
   }

--- a/src/stego.h
+++ b/src/stego.h
@@ -11,10 +11,9 @@
 #define STEGO_KEY_SIZE (STEGO_COVER_FILE_COUNT / CHAR_BIT)
 #define STEGO_LEVELS_PER_PASSWORD 4
 #define STEGO_USER_LEVEL_COUNT 16
-#define STEGO_AES_KEY_SIZE 16
 
 typedef struct {
-  uint8_t aes_key[STEGO_AES_KEY_SIZE];
+  uint8_t aes_key[ENC_KEY_SIZE];
   uint8_t read_keys[STEGO_LEVELS_PER_PASSWORD][STEGO_KEY_SIZE];
   uint8_t write_keys[STEGO_LEVELS_PER_PASSWORD][STEGO_KEY_SIZE];
 } stego_key_t;


### PR DESCRIPTION
Previously, every stego operation performed 10000 iterations of PBKDF2 to generate AES keys, which was unnecessary and prohibitively expensive. Now, stego uses the actual `aes_key` member directly, with an additional IV (cheaply) derived from the offset. In certain benchmarks, this increases write speeds from around 30KiB/s to 1.1MiB/s.

In order to implement this, key derivation had to be decoupled from the actual encryption in the AES API, resulting in some changes to the key table as well.